### PR TITLE
Setting headers for cluster ID and user agent

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4,7 +4,6 @@ var GiantSwarm = (function () {
 
   var authToken = null;
   var clusterId = null;
-  var userAgent = 'giantswarm-js-client';
   var apiEndpoint = 'https://api.giantswarm.io';
   var websocketEndpoint = 'wss://api.giantswarm.io';
 
@@ -68,7 +67,6 @@ var GiantSwarm = (function () {
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
       request
         .get(apiEndpoint + '/v1/ping')
-        .set('User-Agent', userAgent)
         .end(function(err, res){
           if (err) {
             if (errorCallback) errorCallback(err);
@@ -100,7 +98,6 @@ var GiantSwarm = (function () {
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
       request
         .post(apiEndpoint + '/v1/user/' + username + '/login')
-        .set('User-Agent', userAgent)
         .send({'password': base64encode(password)})
         .end(function(err, resp){
           if (err === null) {
@@ -147,16 +144,6 @@ var GiantSwarm = (function () {
     },
 
     /**
-     * Sets the User-Agent header to be sent with subsequent requests
-     */
-    setUserAgent: function(ua) {
-      if (typeof(ua) !== 'string') {
-        throw new this.UserException("Parameter 'ua' must be of type String");
-      }
-      userAgent = ua;
-    },
-
-    /**
      * Internal function to perform an authenticated GET request and handle the response
      *
      * @param {String} [uri] API route to be called, starting with "/"
@@ -169,8 +156,7 @@ var GiantSwarm = (function () {
       if (typeof(successCallback) !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
       var headers = {
-        'Authorization': 'giantswarm ' + authToken,
-        'User-Agent': userAgent
+        'Authorization': 'giantswarm ' + authToken
       }
       if (clusterId) {
         headers[CLUSTER_ID_HEADER] = clusterId;
@@ -200,8 +186,7 @@ var GiantSwarm = (function () {
       if (typeof(createCallback) !== 'function') throw new this.UserException("Parameter 'createCallback' must be a function");
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
       var headers = {
-        'Authorization': 'giantswarm ' + authToken,
-        'User-Agent': userAgent
+        'Authorization': 'giantswarm ' + authToken
       }
       if (clusterId) {
         headers[CLUSTER_ID_HEADER] = clusterId;
@@ -271,8 +256,7 @@ var GiantSwarm = (function () {
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
       var uri = apiEndpoint + '/v1/org/' + organizationName + '/env/';
       var headers = {
-        'Authorization': 'giantswarm ' + authToken,
-        'User-Agent': userAgent
+        'Authorization': 'giantswarm ' + authToken
       }
       if (clusterId) {
         headers[CLUSTER_ID_HEADER] = clusterId;

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,6 +8,8 @@ var GiantSwarm = (function () {
   var apiEndpoint = 'https://api.giantswarm.io';
   var websocketEndpoint = 'wss://api.giantswarm.io';
 
+  var CLUSTER_ID_HEADER = 'X-Giant-Swarm-ClusterID';
+
   var Base64;
   var base64encode;
 
@@ -171,7 +173,7 @@ var GiantSwarm = (function () {
         'User-Agent': userAgent
       }
       if (clusterId) {
-        headers['X-Giant-Swarm-ClusterID'] = clusterId;
+        headers[CLUSTER_ID_HEADER] = clusterId;
       }
       request
         .get(apiEndpoint + uri)
@@ -202,7 +204,7 @@ var GiantSwarm = (function () {
         'User-Agent': userAgent
       }
       if (clusterId) {
-        headers['X-Giant-Swarm-ClusterID'] = clusterId;
+        headers[CLUSTER_ID_HEADER] = clusterId;
       }
       request
         .post(apiEndpoint + uri)
@@ -273,7 +275,7 @@ var GiantSwarm = (function () {
         'User-Agent': userAgent
       }
       if (clusterId) {
-        headers['X-Giant-Swarm-ClusterID'] = clusterId;
+        headers[CLUSTER_ID_HEADER] = clusterId;
       }
       request
         .get(uri)

--- a/lib/client.js
+++ b/lib/client.js
@@ -3,6 +3,8 @@ var request = require('superagent');
 var GiantSwarm = (function () {
 
   var authToken = null;
+  var clusterId = null;
+  var userAgent = 'giantswarm-js-client';
   var apiEndpoint = 'https://api.giantswarm.io';
   var websocketEndpoint = 'wss://api.giantswarm.io';
 
@@ -64,6 +66,7 @@ var GiantSwarm = (function () {
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
       request
         .get(apiEndpoint + '/v1/ping')
+        .set('User-Agent', userAgent)
         .end(function(err, res){
           if (err) {
             if (errorCallback) errorCallback(err);
@@ -95,6 +98,7 @@ var GiantSwarm = (function () {
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
       request
         .post(apiEndpoint + '/v1/user/' + username + '/login')
+        .set('User-Agent', userAgent)
         .send({'password': base64encode(password)})
         .end(function(err, resp){
           if (err === null) {
@@ -131,6 +135,26 @@ var GiantSwarm = (function () {
     },
 
     /**
+     * Sets the Cluster ID to be used with subsequent requests
+     */
+    setClusterId: function(cid) {
+      if (cid !== null && typeof(cid) !== 'string') {
+        throw new this.UserException("Parameter 'cid' must be of type String or null.");
+      }
+      clusterId = cid;
+    },
+
+    /**
+     * Sets the User-Agent header to be sent with subsequent requests
+     */
+    setUserAgent: function(ua) {
+      if (typeof(ua) !== 'string') {
+        throw new this.UserException("Parameter 'ua' must be of type String");
+      }
+      userAgent = ua;
+    },
+
+    /**
      * Internal function to perform an authenticated GET request and handle the response
      *
      * @param {String} [uri] API route to be called, starting with "/"
@@ -142,9 +166,16 @@ var GiantSwarm = (function () {
       if (!successCallback) throw new this.UserException("Parameter successCallback must be given");
       if (typeof(successCallback) !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      var headers = {
+        'Authorization': 'giantswarm ' + authToken,
+        'User-Agent': userAgent
+      }
+      if (clusterId) {
+        headers['X-Giant-Swarm-ClusterID'] = clusterId;
+      }
       request
         .get(apiEndpoint + uri)
-        .set('Authorization', 'giantswarm ' + authToken)
+        .set(headers)
         .end(function(err, resp){
           if (err) {
             if (errorCallback) errorCallback(err);
@@ -166,9 +197,16 @@ var GiantSwarm = (function () {
       if (typeof(messageCallback) !== 'function') throw new this.UserException("Parameter 'messageCallback' must be a function");
       if (typeof(createCallback) !== 'function') throw new this.UserException("Parameter 'createCallback' must be a function");
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      var headers = {
+        'Authorization': 'giantswarm ' + authToken,
+        'User-Agent': userAgent
+      }
+      if (clusterId) {
+        headers['X-Giant-Swarm-ClusterID'] = clusterId;
+      }
       request
         .post(apiEndpoint + uri)
-        .set('Authorization', 'giantswarm ' + authToken)
+        .set(headers)
         .send(postPayload)
         .end(function(err, resp){
           if (err) {
@@ -230,9 +268,16 @@ var GiantSwarm = (function () {
       if (typeof(successCallback) !== 'function') throw new this.UserException('successCallback must be given');
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
       var uri = apiEndpoint + '/v1/org/' + organizationName + '/env/';
+      var headers = {
+        'Authorization': 'giantswarm ' + authToken,
+        'User-Agent': userAgent
+      }
+      if (clusterId) {
+        headers['X-Giant-Swarm-ClusterID'] = clusterId;
+      }
       request
         .get(uri)
-        .set('Authorization', 'giantswarm ' + authToken)
+        .set(headers)
         .end(function(err, resp){
           if (err) {
             if (errorCallback) errorCallback(err);


### PR DESCRIPTION
The purpose of this request is to enable the client to set the `X-Giant-Swarm-ClusterID` header on requests.

While at it I also added the forgotten `User-Agent` header, which will be `giantswarm-js-client` by default. When used in the webclient we can change it to e. g. `webclient/<version>` using the `setUserAgent()` method.

RFR @zyndiecate @ZeissS - Thanks!

Update: Removed the User-Agent header again.