### PR TITLE
Instance logs

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -177,6 +177,39 @@ var GiantSwarm = (function () {
     },
 
     /**
+     * Internal function to perform an authenticated GET request and return the raw body
+     *
+     * @param {String} [uri] API route to be called, starting with "/"
+     * @param {Function} [successCallback] Callback to be called in case of success, gets response data as argument
+     * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
+     * @param {Object} [params] URL parameters to be added (optional)
+     */
+    _simple_get_request: function(uri, successCallback, errorCallback, params) {
+      this._validateStringParameters({uri: uri});
+      if (!successCallback) throw new this.UserException("Parameter successCallback must be given");
+      if (typeof(successCallback) !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
+      if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      var headers = {
+        'Authorization': 'giantswarm ' + authToken
+      }
+      if (clusterId) {
+        headers[CLUSTER_ID_HEADER] = clusterId;
+      }
+      var r = request.get(apiEndpoint + uri);
+      if (params !== null) {
+        r.query(params);
+      }
+      r.set(headers)
+        .end(function(err, resp){
+          if (err) {
+            if (errorCallback) errorCallback(err);
+          } else {
+            if (successCallback) successCallback(resp.body);
+          }
+        });
+    },
+
+    /**
      * Internal function to perform an authenticated POST request and handle the response
      *
      * @param {String} [uri] API route to be called, starting with "/"
@@ -527,7 +560,7 @@ var GiantSwarm = (function () {
         params.t = numLines;
       }
       var uri = '/v1/org/' + organizationName + '/instance/' + instanceId + '/logs';
-      this._simple_data_get_request(uri, successCallback, errorCallback, params);
+      this._simple_get_request(uri, successCallback, errorCallback, params);
     },
 
     /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -149,8 +149,9 @@ var GiantSwarm = (function () {
      * @param {String} [uri] API route to be called, starting with "/"
      * @param {Function} [successCallback] Callback to be called in case of success, gets response data as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
+     * @param {Object} [params] URL parameters to be added (optional)
      */
-    _simple_data_get_request: function(uri, successCallback, errorCallback) {
+    _simple_data_get_request: function(uri, successCallback, errorCallback, params) {
       this._validateStringParameters({uri: uri});
       if (!successCallback) throw new this.UserException("Parameter successCallback must be given");
       if (typeof(successCallback) !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
@@ -161,9 +162,11 @@ var GiantSwarm = (function () {
       if (clusterId) {
         headers[CLUSTER_ID_HEADER] = clusterId;
       }
-      request
-        .get(apiEndpoint + uri)
-        .set(headers)
+      var r = request.get(apiEndpoint + uri);
+      if (params !== null) {
+        r.query(params);
+      }
+      r.set(headers)
         .end(function(err, resp){
           if (err) {
             if (errorCallback) errorCallback(err);

--- a/lib/client.js
+++ b/lib/client.js
@@ -204,7 +204,7 @@ var GiantSwarm = (function () {
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
-            if (successCallback) successCallback(resp.body);
+            if (successCallback) successCallback(resp);
           }
         });
     },

--- a/lib/client.js
+++ b/lib/client.js
@@ -507,6 +507,30 @@ var GiantSwarm = (function () {
     },
 
     /**
+     * Get logs for an instance
+     *
+     * @param {String} [organizationName] Name of the organization
+     * @param {Integer} [numLines] Number of lines to return. If null, 10 lines will be returned.
+     * @param {Function} [successCallback] Callback receiving the statistics object as argument
+     * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
+     */
+    instanceLogs: function(organizationName, instanceId, numLines, successCallback, errorCallback) {
+      this._validateStringParameters({
+        organizationName: organizationName,
+        instanceId: instanceId
+      });
+      if (numLines !== null && typeof numLines !== 'number') {
+        throw new this.UserException("Parameter 'numLines' must be of type Number");
+      }
+      var params = {format: 'json'};
+      if (numLines !== null) {
+        params.t = numLines;
+      }
+      var uri = '/v1/org/' + organizationName + '/instance/' + instanceId + '/logs';
+      this._simple_data_get_request(uri, successCallback, errorCallback, params);
+    },
+
+    /**
      * Create a websocket connection to stream logs from instances
      *
      * @param {String} [organizationName] Name of the organization owning the instance

--- a/lib/client.js
+++ b/lib/client.js
@@ -83,7 +83,7 @@ var GiantSwarm = (function () {
 
     /**
      * Authenticate the client with a user's credentials
-     * 
+     *
      * @param {String} [username] username or email address (String)
      * @param {String} [password] password (String, UTF-8)
      * @param {Function} [successCallback] Optional callback to be called in case of success, no arguments
@@ -116,7 +116,7 @@ var GiantSwarm = (function () {
      * unauthenticated.
      *
      * @param {String} [token] Authentication token
-     */ 
+     */
     setAuthToken: function(token) {
       if (token !== null && typeof(token) !== 'string') {
         throw new this.UserException("Parameter 'token' must be of type String or null.");
@@ -128,7 +128,7 @@ var GiantSwarm = (function () {
      * Return the currently used authentication token
      *
      * @returns {String} Currently used authentication token, might be null.
-     */ 
+     */
     getAuthToken: function() {
       return authToken;
     },
@@ -151,22 +151,21 @@ var GiantSwarm = (function () {
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      * @param {Object} [params] URL parameters to be added (optional)
      */
-    _simple_data_get_request: function(uri, successCallback, errorCallback, params) {
+    _simple_data_get_request: function(uri, params, successCallback, errorCallback) {
       this._validateStringParameters({uri: uri});
       if (!successCallback) throw new this.UserException("Parameter successCallback must be given");
       if (typeof(successCallback) !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      params = params || '';
       var headers = {
         'Authorization': 'giantswarm ' + authToken
       }
       if (clusterId) {
         headers[CLUSTER_ID_HEADER] = clusterId;
       }
-      var r = request.get(apiEndpoint + uri);
-      if (params !== null) {
-        r.query(params);
-      }
-      r.set(headers)
+      request.get(apiEndpoint + uri)
+        .query(params);
+        .set(headers)
         .end(function(err, resp){
           if (err) {
             if (errorCallback) errorCallback(err);
@@ -184,22 +183,21 @@ var GiantSwarm = (function () {
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      * @param {Object} [params] URL parameters to be added (optional)
      */
-    _simple_text_get_request: function(uri, successCallback, errorCallback, params) {
+    _simple_text_get_request: function(uri, params, successCallback, errorCallback) {
       this._validateStringParameters({uri: uri});
       if (!successCallback) throw new this.UserException("Parameter successCallback must be given");
       if (typeof(successCallback) !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      params = params || '';
       var headers = {
         'Authorization': 'giantswarm ' + authToken
       }
       if (clusterId) {
         headers[CLUSTER_ID_HEADER] = clusterId;
       }
-      var r = request.get(apiEndpoint + uri);
-      if (params !== null) {
-        r.query(params);
-      }
-      r.set(headers)
+      request.get(apiEndpoint + uri)
+        .query(params)
+        .set(headers)
         .end(function(err, resp){
           if (err) {
             if (errorCallback) errorCallback(err);
@@ -284,7 +282,7 @@ var GiantSwarm = (function () {
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
     user: function(successCallback, errorCallback) {
-      this._simple_data_get_request('/v1/user/me', successCallback, errorCallback);
+      this._simple_data_get_request('/v1/user/me', null, successCallback, errorCallback);
     },
 
     /**
@@ -294,7 +292,7 @@ var GiantSwarm = (function () {
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
     memberships: function(successCallback, errorCallback) {
-      this._simple_data_get_request('/v1/user/me/memberships', successCallback, errorCallback);
+      this._simple_data_get_request('/v1/user/me/memberships', null, successCallback, errorCallback);
     },
 
     /**
@@ -306,7 +304,8 @@ var GiantSwarm = (function () {
      */
     organization: function(organizationName, successCallback, errorCallback) {
       this._validateStringParameters({organizationName: organizationName});
-      this._simple_data_get_request('/v1/org/' + encodeURIComponent(organizationName), successCallback, errorCallback);
+      var uri = '/v1/org/' + encodeURIComponent(organizationName);
+      this._simple_data_get_request(uri, null, successCallback, errorCallback);
     },
 
     /**
@@ -358,7 +357,7 @@ var GiantSwarm = (function () {
         environmentName: environmentName
       });
       var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/';
-      this._simple_data_get_request(uri, successCallback, errorCallback);
+      this._simple_data_get_request(uri, null, successCallback, errorCallback);
     },
 
     /**
@@ -377,7 +376,7 @@ var GiantSwarm = (function () {
         applicationName: applicationName
       });
       var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName) + '/status';
-      this._simple_data_get_request(uri, successCallback, errorCallback);
+      this._simple_data_get_request(uri, null, successCallback, errorCallback);
     },
 
     /**
@@ -396,7 +395,7 @@ var GiantSwarm = (function () {
         applicationName: applicationName
       });
       var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName) + '/config';
-      this._simple_data_get_request(uri, successCallback, errorCallback);
+      this._simple_data_get_request(uri, null, successCallback, errorCallback);
     },
 
     /**
@@ -457,7 +456,7 @@ var GiantSwarm = (function () {
       });
       var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName);
       uri += '/service/' + encodeURIComponent(serviceName) + '/status';
-      this._simple_data_get_request(uri, successCallback, errorCallback);
+      this._simple_data_get_request(uri, null, successCallback, errorCallback);
     },
 
     /**
@@ -520,7 +519,7 @@ var GiantSwarm = (function () {
       });
       var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName);
       uri += '/service/' + encodeURIComponent(serviceName) + '/component/' + encodeURIComponent(componentName) + '/status';
-      this._simple_data_get_request(uri, successCallback, errorCallback);
+      this._simple_data_get_request(uri, null, successCallback, errorCallback);
     },
 
     /**
@@ -536,7 +535,7 @@ var GiantSwarm = (function () {
         instanceId: instanceId
       });
       var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/instance/' + encodeURIComponent(instanceId) + '/stats';
-      this._simple_data_get_request(uri, successCallback, errorCallback);
+      this._simple_data_get_request(uri, null, successCallback, errorCallback);
     },
 
     /**
@@ -560,7 +559,7 @@ var GiantSwarm = (function () {
         params.t = numLines;
       }
       var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/instance/' + encodeURIComponent(instanceId) + '/logs';
-      this._simple_text_get_request(uri, successCallback, errorCallback, params);
+      this._simple_text_get_request(uri, params, successCallback, errorCallback);
     },
 
     /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -36,7 +36,7 @@ var GiantSwarm = (function () {
         if (!parameters[name]) {
           throw new this.UserException("Parameter '"+ name +"' must be given");
         }
-        if (typeof(parameters[name]) !== 'string') {
+        if (typeof parameters[name] !== 'string') {
           throw new this.UserException("Parameter '"+ name +"' must be of type string");
         }
       }

--- a/lib/client.js
+++ b/lib/client.js
@@ -306,7 +306,7 @@ var GiantSwarm = (function () {
      */
     organization: function(organizationName, successCallback, errorCallback) {
       this._validateStringParameters({organizationName: organizationName});
-      this._simple_data_get_request('/v1/org/' + organizationName, successCallback, errorCallback);
+      this._simple_data_get_request('/v1/org/' + encodeURIComponent(organizationName), successCallback, errorCallback);
     },
 
     /**
@@ -320,7 +320,7 @@ var GiantSwarm = (function () {
       this._validateStringParameters({organizationName: organizationName});
       if (typeof(successCallback) !== 'function') throw new this.UserException('successCallback must be given');
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
-      var uri = apiEndpoint + '/v1/org/' + organizationName + '/env/';
+      var uri = apiEndpoint + '/v1/org/' + encodeURIComponent(organizationName) + '/env/';
       var headers = {
         'Authorization': 'giantswarm ' + authToken
       }
@@ -357,7 +357,7 @@ var GiantSwarm = (function () {
         organizationName: organizationName,
         environmentName: environmentName
       });
-      var uri = '/v1/org/' + organizationName + '/env/' + environmentName + '/app/';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/';
       this._simple_data_get_request(uri, successCallback, errorCallback);
     },
 
@@ -376,7 +376,7 @@ var GiantSwarm = (function () {
         environmentName: environmentName,
         applicationName: applicationName
       });
-      var uri = '/v1/org/' + organizationName + '/env/' + environmentName + '/app/' + applicationName + '/status';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName) + '/status';
       this._simple_data_get_request(uri, successCallback, errorCallback);
     },
 
@@ -395,7 +395,7 @@ var GiantSwarm = (function () {
         environmentName: environmentName,
         applicationName: applicationName
       });
-      var uri = '/v1/org/' + organizationName + '/env/' + environmentName + '/app/' + applicationName + '/config';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName) + '/config';
       this._simple_data_get_request(uri, successCallback, errorCallback);
     },
 
@@ -414,7 +414,7 @@ var GiantSwarm = (function () {
         environmentName: environmentName,
         applicationName: applicationName
       });
-      var uri = '/v1/org/' + organizationName + '/env/' + environmentName + '/app/' + applicationName + '/start';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName) + '/start';
       this._simple_data_post_request(uri, successCallback, errorCallback);
     },
 
@@ -433,7 +433,7 @@ var GiantSwarm = (function () {
         environmentName: environmentName,
         applicationName: applicationName
       });
-      var uri = '/v1/org/' + organizationName + '/env/' + environmentName + '/app/' + applicationName + '/stop';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName) + '/stop';
       this._simple_data_post_request(uri, successCallback, errorCallback);
     },
 
@@ -455,8 +455,8 @@ var GiantSwarm = (function () {
         applicationName: applicationName,
         serviceName: serviceName
       });
-      var uri = '/v1/org/' + organizationName + '/env/' + environmentName + '/app/' + applicationName;
-      uri += '/service/' + serviceName + '/status';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName);
+      uri += '/service/' + encodeURIComponent(serviceName) + '/status';
       this._simple_data_get_request(uri, successCallback, errorCallback);
     },
 
@@ -476,7 +476,7 @@ var GiantSwarm = (function () {
         environmentName: environmentName,
         applicationName: applicationName
       });
-      var uri = '/v1/org/' + organizationName + '/env/' + environmentName + '/app/' + applicationName + '/service/' + serviceName + '/start';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName) + '/service/' + encodeURIComponent(serviceName) + '/start';
       this._simple_data_post_request(uri, successCallback, errorCallback);
     },
 
@@ -496,7 +496,7 @@ var GiantSwarm = (function () {
         environmentName: environmentName,
         applicationName: applicationName
       });
-      var uri = '/v1/org/' + organizationName + '/env/' + environmentName + '/app/' + applicationName + '/service/' + serviceName + '/stop';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName) + '/service/' + encodeURIComponent(serviceName) + '/stop';
       this._simple_data_post_request(uri, successCallback, errorCallback);
     },
 
@@ -518,8 +518,8 @@ var GiantSwarm = (function () {
         serviceName: serviceName,
         componentName: componentName
       });
-      var uri = '/v1/org/' + organizationName + '/env/' + environmentName + '/app/' + applicationName;
-      uri += '/service/' + serviceName + '/component/' + componentName + '/status';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/app/' + encodeURIComponent(applicationName);
+      uri += '/service/' + encodeURIComponent(serviceName) + '/component/' + encodeURIComponent(componentName) + '/status';
       this._simple_data_get_request(uri, successCallback, errorCallback);
     },
 
@@ -535,7 +535,7 @@ var GiantSwarm = (function () {
         organizationName: organizationName,
         instanceId: instanceId
       });
-      var uri = '/v1/org/' + organizationName + '/instance/' + instanceId + '/stats';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/instance/' + encodeURIComponent(instanceId) + '/stats';
       this._simple_data_get_request(uri, successCallback, errorCallback);
     },
 
@@ -559,7 +559,7 @@ var GiantSwarm = (function () {
       if (numLines !== null) {
         params.t = numLines;
       }
-      var uri = '/v1/org/' + organizationName + '/instance/' + instanceId + '/logs';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/instance/' + encodeURIComponent(instanceId) + '/logs';
       this._simple_text_get_request(uri, successCallback, errorCallback, params);
     },
 
@@ -580,7 +580,7 @@ var GiantSwarm = (function () {
       if (typeof(messageCallback) !== 'function') throw new this.UserException("Parameter 'messageCallback' must be a function");
       if (typeof(createCallback) !== 'function') throw new this.UserException("Parameter 'createCallback' must be a function");
       if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
-      var uri = '/v1/org/' + organizationName + '/stream/logs';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/stream/logs';
       var postPayload = {instances: instanceIds};
       this._postForWebSocket(uri,
         postPayload,
@@ -607,7 +607,7 @@ var GiantSwarm = (function () {
       if (typeof(instanceIds) !== 'object') throw new this.UserException("Parameter 'instanceIds' must be an array");
       if (typeof(interval) !== 'number') throw new this.UserException("Parameter 'interval' must be a number");
       if (interval < 2) throw new this.UserException("Value or parameter 'interval' must be min 2");
-      var uri = '/v1/org/' + organizationName + '/stream/stats';
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/stream/stats';
       var postPayload = {instances: instanceIds, interval: interval};
       this._postForWebSocket(uri,
         postPayload,

--- a/lib/client.js
+++ b/lib/client.js
@@ -12,7 +12,7 @@ var GiantSwarm = (function () {
   var Base64;
   var base64encode;
 
-  if (typeof(window) === 'undefined') {
+  if (typeof window === 'undefined') {
     Base64 = require('js-base64').Base64;
     base64encode = Base64.encode;
   } else {
@@ -63,15 +63,15 @@ var GiantSwarm = (function () {
      * @param {Function} [errorCallback] Callback to be called in case of an error, error object as argument
      */
     ping: function(successCallback, errorCallback) {
-      if (typeof(successCallback) !== 'function') throw new this.UserException('successCallback must be given');
-      if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      if (typeof successCallback !== 'function') throw new this.UserException('successCallback must be given');
+      if (errorCallback !== null && typeof errorCallback !== 'function') throw new this.UserException('errorCallback must be null or function');
       request
         .get(apiEndpoint + '/v1/ping')
         .end(function(err, res){
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
-            if (typeof(res.text) !== 'undefined' && res.text.trim() === '"OK"') {
+            if (typeof res.text !== 'undefined' && res.text.trim() === '"OK"') {
               if (successCallback) successCallback();
             } else {
               // calling error callback with no argument
@@ -94,8 +94,8 @@ var GiantSwarm = (function () {
         username: username,
         password: password
       });
-      if (successCallback !== null && typeof(successCallback) !== 'function') throw new this.UserException('successCallback must be null or function');
-      if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      if (successCallback !== null && typeof successCallback !== 'function') throw new this.UserException('successCallback must be null or function');
+      if (errorCallback !== null && typeof errorCallback !== 'function') throw new this.UserException('errorCallback must be null or function');
       request
         .post(apiEndpoint + '/v1/user/' + username + '/login')
         .send({'password': base64encode(password)})
@@ -118,7 +118,7 @@ var GiantSwarm = (function () {
      * @param {String} [token] Authentication token
      */
     setAuthToken: function(token) {
-      if (token !== null && typeof(token) !== 'string') {
+      if (token !== null && typeof token !== 'string') {
         throw new this.UserException("Parameter 'token' must be of type String or null.");
       }
       authToken = token;
@@ -137,7 +137,7 @@ var GiantSwarm = (function () {
      * Sets the Cluster ID to be used with subsequent requests
      */
     setClusterId: function(cid) {
-      if (cid !== null && typeof(cid) !== 'string') {
+      if (cid !== null && typeof cid !== 'string') {
         throw new this.UserException("Parameter 'cid' must be of type String or null.");
       }
       clusterId = cid;
@@ -154,8 +154,8 @@ var GiantSwarm = (function () {
     _simple_data_get_request: function(uri, params, successCallback, errorCallback) {
       this._validateStringParameters({uri: uri});
       if (!successCallback) throw new this.UserException("Parameter successCallback must be given");
-      if (typeof(successCallback) !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
-      if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      if (typeof successCallback !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
+      if (errorCallback !== null && typeof errorCallback !== 'function') throw new this.UserException('errorCallback must be null or function');
       params = params || '';
       var headers = {
         'Authorization': 'giantswarm ' + authToken
@@ -186,8 +186,8 @@ var GiantSwarm = (function () {
     _simple_text_get_request: function(uri, params, successCallback, errorCallback) {
       this._validateStringParameters({uri: uri});
       if (!successCallback) throw new this.UserException("Parameter successCallback must be given");
-      if (typeof(successCallback) !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
-      if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      if (typeof successCallback !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
+      if (errorCallback !== null && typeof errorCallback !== 'function') throw new this.UserException('errorCallback must be null or function');
       params = params || '';
       var headers = {
         'Authorization': 'giantswarm ' + authToken
@@ -217,8 +217,8 @@ var GiantSwarm = (function () {
     _simple_data_post_request: function(uri, successCallback, errorCallback) {
       this._validateStringParameters({uri: uri});
       if (!successCallback) throw new this.UserException("Parameter successCallback must be given");
-      if (typeof(successCallback) !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
-      if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      if (typeof successCallback !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
+      if (errorCallback !== null && typeof errorCallback !== 'function') throw new this.UserException('errorCallback must be null or function');
       var headers = {
         'Authorization': 'giantswarm ' + authToken
       }
@@ -245,10 +245,10 @@ var GiantSwarm = (function () {
       this._validateStringParameters({
         uri: uri,
       });
-      if (typeof(postPayload) !== 'object') throw new this.UserException("Parameter 'postPayload' must be an array");
-      if (typeof(messageCallback) !== 'function') throw new this.UserException("Parameter 'messageCallback' must be a function");
-      if (typeof(createCallback) !== 'function') throw new this.UserException("Parameter 'createCallback' must be a function");
-      if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      if (typeof postPayload !== 'object') throw new this.UserException("Parameter 'postPayload' must be an array");
+      if (typeof messageCallback !== 'function') throw new this.UserException("Parameter 'messageCallback' must be a function");
+      if (typeof createCallback !== 'function') throw new this.UserException("Parameter 'createCallback' must be a function");
+      if (errorCallback !== null && typeof errorCallback !== 'function') throw new this.UserException('errorCallback must be null or function');
       var headers = {
         'Authorization': 'giantswarm ' + authToken
       }
@@ -317,8 +317,8 @@ var GiantSwarm = (function () {
      */
     environments: function(organizationName, successCallback, errorCallback) {
       this._validateStringParameters({organizationName: organizationName});
-      if (typeof(successCallback) !== 'function') throw new this.UserException('successCallback must be given');
-      if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      if (typeof successCallback !== 'function') throw new this.UserException('successCallback must be given');
+      if (errorCallback !== null && typeof errorCallback !== 'function') throw new this.UserException('errorCallback must be null or function');
       var uri = apiEndpoint + '/v1/org/' + encodeURIComponent(organizationName) + '/env/';
       var headers = {
         'Authorization': 'giantswarm ' + authToken
@@ -575,10 +575,10 @@ var GiantSwarm = (function () {
       this._validateStringParameters({
         organizationName: organizationName,
       });
-      if (typeof(instanceIds) !== 'object') throw new this.UserException("Parameter 'instanceIds' must be an array");
-      if (typeof(messageCallback) !== 'function') throw new this.UserException("Parameter 'messageCallback' must be a function");
-      if (typeof(createCallback) !== 'function') throw new this.UserException("Parameter 'createCallback' must be a function");
-      if (errorCallback !== null && typeof(errorCallback) !== 'function') throw new this.UserException('errorCallback must be null or function');
+      if (typeof instanceIds !== 'object') throw new this.UserException("Parameter 'instanceIds' must be an array");
+      if (typeof messageCallback !== 'function') throw new this.UserException("Parameter 'messageCallback' must be a function");
+      if (typeof createCallback !== 'function') throw new this.UserException("Parameter 'createCallback' must be a function");
+      if (errorCallback !== null && typeof errorCallback !== 'function') throw new this.UserException('errorCallback must be null or function');
       var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/stream/logs';
       var postPayload = {instances: instanceIds};
       this._postForWebSocket(uri,
@@ -603,8 +603,8 @@ var GiantSwarm = (function () {
       this._validateStringParameters({
         organizationName: organizationName,
       });
-      if (typeof(instanceIds) !== 'object') throw new this.UserException("Parameter 'instanceIds' must be an array");
-      if (typeof(interval) !== 'number') throw new this.UserException("Parameter 'interval' must be a number");
+      if (typeof instanceIds !== 'object') throw new this.UserException("Parameter 'instanceIds' must be an array");
+      if (typeof interval !== 'number') throw new this.UserException("Parameter 'interval' must be a number");
       if (interval < 2) throw new this.UserException("Value or parameter 'interval' must be min 2");
       var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/stream/stats';
       var postPayload = {instances: instanceIds, interval: interval};
@@ -619,9 +619,9 @@ var GiantSwarm = (function () {
 
 })();
 
-if (typeof(window) !== "undefined") {
+if (typeof window !== "undefined") {
   window.GiantSwarm = GiantSwarm;
 }
-if (typeof(module) !== "undefined") {
+if (typeof module !== "undefined") {
   module.exports = GiantSwarm;
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -522,7 +522,7 @@ var GiantSwarm = (function () {
       if (numLines !== null && typeof numLines !== 'number') {
         throw new this.UserException("Parameter 'numLines' must be of type Number");
       }
-      var params = {format: 'json'};
+      var params = {};
       if (numLines !== null) {
         params.t = numLines;
       }

--- a/lib/client.js
+++ b/lib/client.js
@@ -551,8 +551,9 @@ var GiantSwarm = (function () {
         organizationName: organizationName,
         instanceId: instanceId
       });
-      if (numLines !== null && typeof numLines !== 'number') {
-        throw new this.UserException("Parameter 'numLines' must be of type Number");
+      if (numLines === null || typeof numLines !== 'number' || isNaN(numLines) || parseInt(Number(numLines)) !== numLines
+        || isNaN(parseInt(numLines, 10)) || numLines <= 0) {
+        throw new this.UserException("Parameter 'numLines' must be a positive integer");
       }
       var params = {};
       if (numLines !== null) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -164,7 +164,7 @@ var GiantSwarm = (function () {
         headers[CLUSTER_ID_HEADER] = clusterId;
       }
       request.get(apiEndpoint + uri)
-        .query(params);
+        .query(params)
         .set(headers)
         .end(function(err, resp){
           if (err) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -184,7 +184,7 @@ var GiantSwarm = (function () {
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      * @param {Object} [params] URL parameters to be added (optional)
      */
-    _simple_get_request: function(uri, successCallback, errorCallback, params) {
+    _simple_text_get_request: function(uri, successCallback, errorCallback, params) {
       this._validateStringParameters({uri: uri});
       if (!successCallback) throw new this.UserException("Parameter successCallback must be given");
       if (typeof(successCallback) !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
@@ -204,7 +204,7 @@ var GiantSwarm = (function () {
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
-            if (successCallback) successCallback(resp);
+            if (successCallback) successCallback(resp.text);
           }
         });
     },
@@ -560,7 +560,7 @@ var GiantSwarm = (function () {
         params.t = numLines;
       }
       var uri = '/v1/org/' + organizationName + '/instance/' + instanceId + '/logs';
-      this._simple_get_request(uri, successCallback, errorCallback, params);
+      this._simple_text_get_request(uri, successCallback, errorCallback, params);
     },
 
     /**


### PR DESCRIPTION
The purpose of this change is to make instance logs accessible.

The API method for logs doesn't return JSON, so it's a bit different form most others. This requires a new internal `_simple_text_get_request` method.

Logs can be accessed through the `instanceLogs()` method.