### PR TITLE
Adding callback for 401 responses

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -179,7 +179,7 @@ var GiantSwarm = (function () {
         .query(params)
         .set(headers)
         .end(function(err, resp){
-          if (resp && typeof resp.unauthorized !== 'undefined' && unauthorizedCallback) unauthorizedCallback();
+          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback(resp, err);
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
@@ -212,7 +212,7 @@ var GiantSwarm = (function () {
         .query(params)
         .set(headers)
         .end(function(err, resp){
-          if (resp && typeof resp.unauthorized !== 'undefined' && unauthorizedCallback) unauthorizedCallback();
+          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback(resp, err);
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
@@ -243,7 +243,7 @@ var GiantSwarm = (function () {
         .post(apiEndpoint + uri)
         .set(headers)
         .end(function(err, resp){
-          if (resp && typeof resp.unauthorized !== 'undefined' && unauthorizedCallback) unauthorizedCallback();
+          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback(resp, err);
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
@@ -275,7 +275,7 @@ var GiantSwarm = (function () {
         .set(headers)
         .send(postPayload)
         .end(function(err, resp){
-          if (resp && typeof resp.unauthorized !== 'undefined' && unauthorizedCallback) unauthorizedCallback();
+          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback(resp, err);
           if (err) {
             errorCallback(err);
           } else {
@@ -346,7 +346,7 @@ var GiantSwarm = (function () {
         .get(uri)
         .set(headers)
         .end(function(err, resp){
-          if (resp && typeof resp.unauthorized !== 'undefined' && unauthorizedCallback) unauthorizedCallback();
+          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback(resp, err);
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {

--- a/lib/client.js
+++ b/lib/client.js
@@ -179,7 +179,7 @@ var GiantSwarm = (function () {
         .query(params)
         .set(headers)
         .end(function(err, resp){
-          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback();
+          if (resp && typeof resp.unauthorized !== 'undefined' && unauthorizedCallback) unauthorizedCallback();
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
@@ -212,7 +212,7 @@ var GiantSwarm = (function () {
         .query(params)
         .set(headers)
         .end(function(err, resp){
-          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback();
+          if (resp && typeof resp.unauthorized !== 'undefined' && unauthorizedCallback) unauthorizedCallback();
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
@@ -243,7 +243,7 @@ var GiantSwarm = (function () {
         .post(apiEndpoint + uri)
         .set(headers)
         .end(function(err, resp){
-          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback();
+          if (resp && typeof resp.unauthorized !== 'undefined' && unauthorizedCallback) unauthorizedCallback();
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
@@ -275,7 +275,7 @@ var GiantSwarm = (function () {
         .set(headers)
         .send(postPayload)
         .end(function(err, resp){
-          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback();
+          if (resp && typeof resp.unauthorized !== 'undefined' && unauthorizedCallback) unauthorizedCallback();
           if (err) {
             errorCallback(err);
           } else {
@@ -346,7 +346,7 @@ var GiantSwarm = (function () {
         .get(uri)
         .set(headers)
         .end(function(err, resp){
-          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback();
+          if (resp && typeof resp.unauthorized !== 'undefined' && unauthorizedCallback) unauthorizedCallback();
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {

--- a/lib/client.js
+++ b/lib/client.js
@@ -12,6 +12,8 @@ var GiantSwarm = (function () {
   var Base64;
   var base64encode;
 
+  var unauthorizedCallback;
+
   if (typeof window === 'undefined') {
     Base64 = require('js-base64').Base64;
     base64encode = Base64.encode;
@@ -144,6 +146,16 @@ var GiantSwarm = (function () {
     },
 
     /**
+     * Allows to set a callback function to be called when a 401 (Unauthorized) error is received
+     */
+    setUnauthorizedCallback: function(callback) {
+      if (typeof callback !== 'function') {
+        throw new this.UserException("Parameter 'callback' must be of type function.");
+      }
+      unauthorizedCallback = callback;
+    },
+
+    /**
      * Internal function to perform an authenticated GET request and handle the response
      *
      * @param {String} [uri] API route to be called, starting with "/"
@@ -167,6 +179,7 @@ var GiantSwarm = (function () {
         .query(params)
         .set(headers)
         .end(function(err, resp){
+          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback();
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
@@ -199,6 +212,7 @@ var GiantSwarm = (function () {
         .query(params)
         .set(headers)
         .end(function(err, resp){
+          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback();
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
@@ -229,6 +243,7 @@ var GiantSwarm = (function () {
         .post(apiEndpoint + uri)
         .set(headers)
         .end(function(err, resp){
+          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback();
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {
@@ -260,6 +275,7 @@ var GiantSwarm = (function () {
         .set(headers)
         .send(postPayload)
         .end(function(err, resp){
+          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback();
           if (err) {
             errorCallback(err);
           } else {
@@ -330,6 +346,7 @@ var GiantSwarm = (function () {
         .get(uri)
         .set(headers)
         .end(function(err, resp){
+          if (resp.unauthorized && unauthorizedCallback) unauthorizedCallback();
           if (err) {
             if (errorCallback) errorCallback(err);
           } else {

--- a/lib/client.js
+++ b/lib/client.js
@@ -631,6 +631,56 @@ var GiantSwarm = (function () {
         messageCallback,
         createCallback,
         errorCallback);
+    },
+
+    /**
+     * Expire the auth token currently used
+     *
+     * @param {Function} [successCallback] Callback to be called in case of success, gets response data as argument
+     * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
+     */
+    logout: function(successCallback, errorCallback) {
+      if (!successCallback) throw new this.UserException("Parameter successCallback must be given");
+      if (typeof successCallback !== 'function') throw new this.UserException("Parameter successCallback must be of type function");
+      if (errorCallback !== null && typeof errorCallback !== 'function') throw new this.UserException('errorCallback must be null or function');
+      var headers = {
+        'Authorization': 'giantswarm ' + authToken
+      }
+      if (clusterId) {
+        headers[CLUSTER_ID_HEADER] = clusterId;
+      }
+      request
+        .post(apiEndpoint + '/v1/token/logout')
+        .set(headers)
+        .end(function(err, resp){
+          if (err) {
+            if (errorCallback) errorCallback(err);
+          } else {
+            authToken = null;
+            if (successCallback) successCallback(resp.body);
+          }
+        });
+    },
+
+    /**
+     * Return true if the cleitn is authenticated, otherwise return false
+     */
+    isAuthenticated: function(responseCallback) {
+      if (!responseCallback) throw new this.UserException("Parameter responseCallback must be given");
+      if (typeof responseCallback !== 'function') throw new this.UserException("Parameter responseCallback must be of type function");
+      var answer = false;
+      if (authToken === null) {
+        responseCallback(answer);
+      } else {
+        // check auth status with the API
+        this.user(function(data){
+          answer = true;
+          responseCallback(answer);
+        }, function(err) {
+          // TODO: only report false if response code was 401
+          responseCallback(answer);
+        });
+      }
     }
 
   };


### PR DESCRIPTION
RFR @oponder

Allows to set a special callback function to be called when a 401 (Unauthorized) error is received. The webclient uses this to end the session.