### PR TITLE
apiEndPoint debug method, back to mainstream superagent-mock

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -67,6 +67,10 @@ var GiantSwarm = (function () {
       websocketEndpoint = wsurl;
     },
 
+    getApiEndpoint: function(url) {
+      return apiEndpoint;
+    },
+
     /**
      * Check the availability of the API
      *

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "js-data": "2.3.0",
     "superagent": "1.3.0",
-    "superagent-mock": "git@github.com:oponder/superagent-mock.git",
+    "superagent-mock": "1.7.0",
     "js-base64": "^2.1.8",
     "ws": "0.7.2"
   },

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -44,6 +44,20 @@ describe("GiantSwarm", function() {
     done();
   });
 
+  it("should fetch organizations which the current user is a member of", function(done){
+    GiantSwarm.setApiEndpoint("https://api.example.io");
+    GiantSwarm.setAuthToken("valid_token");
+    GiantSwarm.memberships(function(data){
+      expect(typeof(data)).toEqual('object');
+      expect(data.length).toBeGreaterThan(0);
+      expect(typeof(data[0])).toEqual('string');
+      done();
+    }, function(err){
+      fail(err);
+      done();
+    });
+  });
+
   // ping
 
   it("should allow me to ping the right server", function(done){

--- a/spec/superagent-mock-config.js
+++ b/spec/superagent-mock-config.js
@@ -20,7 +20,7 @@ module.exports = [
     /**
      * regular expression of URL
      */
-    pattern: 'https://api.giantswarm.io(.*)',
+    pattern: 'https://api.*?io(.*)',
 
     /**
      * returns the data


### PR DESCRIPTION
This shouldn't be needed to fix any current issues, but sensible changes that can be merged at somepoint.