### PR TITLE
Return null for golang zero dates

### DIFF
--- a/lib/request_helper.js
+++ b/lib/request_helper.js
@@ -1,4 +1,5 @@
 agent = require('superagent');
+_ = require('underscore')
 
 var requestHelper = (function() {
   return {
@@ -26,6 +27,20 @@ var requestHelper = (function() {
         response.ok = true
         response.body = {}
         response.body.data = response.text
+      }
+
+      // Convert 0001-01-01T00:00:00Z to null
+      if(this._checkNested(response, 'body', 'data', 'components')) {
+        // If the response contains components,
+        // loop over them and check for and replace the null date
+
+        _.each(response.body.data.components, function(component){
+          _.each(component.instances, function(instance){
+            if(instance.create_date === "0001-01-01T00:00:00Z") {
+              instance.create_date = null;
+            }
+          })
+        })
       }
 
       if (response.ok) { onSuccess(response.body.data); return }
@@ -60,6 +75,19 @@ var requestHelper = (function() {
             onError: params.onError
           })
         }.bind(this));
+    },
+
+    // Checks for the presence of a nested key
+    _checkNested: function(obj /*, level1, level2, ... levelN*/) {
+      var args = Array.prototype.slice.call(arguments, 1);
+
+      for (var i = 0; i < args.length; i++) {
+        if (!obj || !obj.hasOwnProperty(args[i])) {
+          return false;
+        }
+        obj = obj[args[i]];
+      }
+      return true;
     },
 
     get: function(params) {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "url": "giantswarm/giantswarm-js-client"
   },
   "dependencies": {
+    "js-base64": "^2.1.8",
     "js-data": "2.3.0",
     "superagent": "1.3.0",
     "superagent-mock": "1.7.0",
-    "js-base64": "^2.1.8",
+    "underscore": "^1.8.3",
     "ws": "0.7.2"
   },
   "devDependencies": {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -239,6 +239,7 @@ describe("GiantSwarm", function() {
         expect(typeof(data.components)).not.toEqual('undefined');
         expect(typeof(data.components[0].instances[0].id)).not.toEqual('undefined');
         expect(typeof(data.components[0].instances[0].status)).not.toEqual('undefined');
+        expect(data.components[0].instances[0].create_date).toEqual('2015-08-13T08:46:46.827236888Z');
         expect(typeof(data.status)).not.toEqual('undefined');
         done();
       }, function(err){
@@ -525,4 +526,20 @@ describe("GiantSwarm", function() {
         done();
       });
   });
+
+  // Null Dates
+
+  it("converts 0001-01-01T00:00:00Z to null for dates", function(done) {
+    GiantSwarm.setAuthToken("valid_token");
+    GiantSwarm.serviceStatus(configuration.organizationName,
+      configuration.environmentName,
+      "deleting_service",
+      function(data){
+        expect(data.components[0].instances[0].create_date).toEqual(null);
+        done();
+      }, function(err){
+        fail(err);
+        done();
+      });
+  })
 });

--- a/spec/mock_api/v1/org_env_service_status_deleting.js
+++ b/spec/mock_api/v1/org_env_service_status_deleting.js
@@ -1,0 +1,40 @@
+var match = function match(match, params, headers) {
+  if (match[1] === '/v1/org/oponder/env/dev/service/deleting_service/status') {
+    return {
+      body: {
+        "status_code": 10000,
+        "status_text": "success",
+        "data": {
+          "name": "deleting_service",
+          "version": "V2GiantSwarm",
+          "status": "up",
+          "components": [
+            {
+              "name": "webserver",
+              "min": 1,
+              "max": 10,
+              "status": "up",
+              "instances": [
+                {
+                  "id": "qub9nwzu234u",
+                  "status": "deleting",
+                  "create_date": "0001-01-01T00:00:00Z",
+                  "image": "nginx:latest",
+                  "image_hash": "6886fb5a9b8d73b12d842bab8f9a6941c36094c2974abddb685d54c9d99e37da"
+                },
+                {
+                  "id": "qub9nwzu2343",
+                  "status": "deleting",
+                  "create_date": "0001-01-01T00:00:00Z",
+                  "image": "nginx:latest",
+                  "image_hash": "6886fb5a9b8d73b12d842bab8f9a6941c36094c2974abddb685d54c9d99e37da"
+                },
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+module.exports = match;


### PR DESCRIPTION
Related to: https://github.com/giantswarm/webclient/issues/123

Also, I am tempted to immediately parse dates and return proper (moment.js) date objects right here
instead of the date string.

That way any client that depends on this libary will always get a proper date object
which it can depend on.

Something to consider!