### PR TITLE
Fix bug: "Cannot read property 'data' of null" in instance logs

### DIFF
--- a/lib/request_helper.js
+++ b/lib/request_helper.js
@@ -23,7 +23,7 @@ var requestHelper = (function() {
 
       // Slime in the ok and body.data properties
       // for the instance logs api call.
-      if(! response.body && response.text && ! error) {
+      if(! response.body && typeof response.text === "string" && ! error) {
         response.ok = true
         response.body = {}
         response.body.data = response.text

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -421,6 +421,18 @@ describe("GiantSwarm", function() {
       });
   });
 
+  it("works when there are no log lines returned", function(done) {
+    GiantSwarm.instanceLogs(configuration.organizationName,
+      "instanceWithNoLogs",
+      null,
+      function(data){
+        done();
+      }, function(err){
+        fail(err);
+        done();
+      });
+  })
+
   it("responds with 2 lines when asked", function(done){
     GiantSwarm.instanceLogs(configuration.organizationName,
       configuration.instanceId,

--- a/spec/mock_api/v1/org_instance_logs.js
+++ b/spec/mock_api/v1/org_instance_logs.js
@@ -10,5 +10,11 @@ var match = function match(match, params, headers) {
       text: "Line 1\nLine 2"
     }
   }
+
+  if (match[1] === '/v1/org/oponder/instance/instanceWithNoLogs/logs?t=10') {
+    return {
+      text: ""
+    }
+  }
 }
 module.exports = match;


### PR DESCRIPTION
Related to: https://github.com/giantswarm/webclient/issues/140