### PR TITLE
Fix webclient #179 - Webclient login fails with non-ASCII character in password

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,5 @@
 var requestHelper = require("./request_helper");
+var Base64 = require("js-base64").Base64;
 
 if (typeof WebSocket === "undefined") {
   var WebSocket = require("ws");
@@ -14,14 +15,8 @@ var GiantSwarm = (function () {
 
   var CLUSTER_ID_HEADER = "X-Giant-Swarm-ClusterID";
 
-  var Base64;
-  var base64encode;
-
-  if (typeof window === "undefined") {
-    Base64 = require("js-base64").Base64;
-    base64encode = Base64.encode;
-  } else {
-    base64encode = window.btoa;
+  var base64encode = function (str) {
+    return Base64.encode(str);
   }
 
   return {


### PR DESCRIPTION
This will fix https://github.com/giantswarm/webclient/issues/179 

window.btoa doesn't handle unicode characters well. js-base64 is great at handling it.
So lets use it always. 

https://developer.mozilla.org/en/docs/Web/API/WindowBase64/Base64_encoding_and_decoding