### PR TITLE
Add setActivity and RequestID

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,16 @@
+{
+  "ecmaFeatures": {
+    "jsx": true,
+    "modules": true,
+    "classes": true
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "es6": true
+  },
+  "rules": {
+    "no-underscore-dangle": 0,
+    "quotes": [1, "single"]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For details about the Giant Swarm API, please check out the [API documentation](
 ## Usage
 
 ```javascript
-giantSwarm = new giantSwarm();
+giantSwarm = new GiantSwarm();
 giantSwarm.ping(function(){
     console.log("All right.");
 }, function(err) {

--- a/README.md
+++ b/README.md
@@ -69,3 +69,9 @@ gulp
 ```
 npm test
 ```
+
+## Running lint
+
+```
+gulp eslint
+```

--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@ For details about the Giant Swarm API, please check out the [API documentation](
 ## Usage
 
 ```javascript
-GiantSwarm.ping(function(){
+giantSwarm = new giantSwarm();
+giantSwarm.ping(function(){
     console.log("All right.");
 }, function(err) {
     console.log("Something isn't right", err);
 });
 
-GiantSwarm.authenticate("my-username", "my-password", function(){
+giantSwarm.authenticate("my-username", "my-password", function(){
     console.log("Login successful");
 }, function(err){
     console.log("Login error.", err);
 });
 
-GiantSwarm.applicationStatus("my-org", "my-env", "my-app", function(d){
+giantSwarm.applicationStatus("my-org", "my-env", "my-app", function(d){
     console.log(d);
 }, function(err){
     console.log(err);
@@ -50,7 +51,7 @@ function errorCallback(err) {
 var organizationName = 'my-org';
 var instanceIds = ['4lyqvwvqhg0m'];
 
-GiantSwarm.streamLogs(organizationName, instanceIds, messageCallback, socketCreateCallback, errorCallback);
+giantSwarm.streamLogs(organizationName, instanceIds, messageCallback, socketCreateCallback, errorCallback);
 ```
 
 See `lib/client.js` for more methods.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ var gutil = require('gulp-util');
 var eslint = require('gulp-eslint');
 
 gulp.task('eslint', function() {
-  return gulp.src('./lib/client.js')
+  return gulp.src(['./lib/client.js', './lib/request_helper.js'])
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failOnError());

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,6 +5,8 @@ if (typeof WebSocket === "undefined") {
   var WebSocket = require("ws");
 }
 
+var uuid = require("node-uuid");
+
 var GiantSwarm = (function () {
   "use strict";
 
@@ -15,19 +17,7 @@ var GiantSwarm = (function () {
   }
 
   return function(){
-    this._generateRequestID = function() {
-      // I just picked something from the internet:
-      // http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
-      //
-      // It has caveats but for our purposes should be good enough.
-
-      return ('xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-        var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
-        return v.toString(16);
-      }));
-    }
-
-    var requestID = this._generateRequestID();
+    var requestID = uuid.v4();
     var requestHelper = new RequestHelper(requestID);
     var authToken = null;
     var clusterId = null;

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,46 +1,47 @@
-"use strict";
-var RequestHelper = require("./request_helper");
-var Base64 = require("js-base64").Base64;
-var UserException = require('./user_exception.js')
+'use strict';
+var RequestHelper = require('./request_helper');
+var Base64 = require('js-base64').Base64;
+var UserException = require('./user_exception.js');
 
-if (typeof WebSocket === "undefined") {
-  var WebSocket = require("ws");
+if (typeof WebSocket === 'undefined') {
+  var WebSocket = require('ws');
 }
 
-var uuid = require("node-uuid");
+var uuid = require('node-uuid');
 
 var GiantSwarm = (function () {
-  var CLUSTER_ID_HEADER = "X-Giant-Swarm-ClusterID";
+
+  var CLUSTER_ID_HEADER = 'X-Giant-Swarm-ClusterID';
 
   var base64encode = function (str) {
     return Base64.encode(str);
-  }
+  };
 
   return function(){
     var requestID = uuid.v4();
     var requestHelper = new RequestHelper(requestID);
     var authToken = null;
     var clusterId = null;
-    var apiEndpoint = "https://api.giantswarm.io";
-    var websocketEndpoint = "wss://api.giantswarm.io";
+    var apiEndpoint = 'https://api.giantswarm.io';
+    var websocketEndpoint = 'wss://api.giantswarm.io';
 
     // simplify validation of string parameters for internal methods
     this._validateStringParameters = function(parameters) {
       for (var name in parameters) {
         if (!parameters[name]) {
-          throw new UserException("Parameter '" + name + "' must be given");
+          throw new UserException('Parameter "' + name + '" must be given');
         }
-        if (typeof parameters[name] !== "string") {
-          throw new UserException("Parameter '" + name + "' must be of type string");
+        if (typeof parameters[name] !== 'string') {
+          throw new UserException('Parameter "' + name + '" must be of type string');
         }
       }
-    }
+    };
 
     // Internal method to get the websocketEndpoint
     // mainly to make setApiEndpoint testable
     this._getWebsocketEndpoint = function() {
       return websocketEndpoint;
-    }
+    };
 
     /**
      * Allows the user to overwrite the default API endpoint
@@ -51,14 +52,14 @@ var GiantSwarm = (function () {
     this.setApiEndpoint = function(url) {
       this._validateStringParameters({url: url});
       apiEndpoint = url;
-      var wsurl = url.replace("http://", "ws://");
-      wsurl = wsurl.replace("https://", "wss://");
+      var wsurl = url.replace('http://', 'ws://');
+      wsurl = wsurl.replace('https://', 'wss://');
       websocketEndpoint = wsurl;
-    }
+    };
 
-    this.getApiEndpoint = function(url) {
+    this.getApiEndpoint = function() {
       return apiEndpoint;
-    }
+    };
 
     /**
      * Allow the user to set the activity they are performing with this client
@@ -70,7 +71,7 @@ var GiantSwarm = (function () {
     this.setActivity = function(activityName) {
       this._validateStringParameters({activityName: activityName});
       requestHelper.setActivity(activityName);
-    }
+    };
 
     /**
      * Check the availability of the API
@@ -80,14 +81,14 @@ var GiantSwarm = (function () {
      */
     this.ping = function(successCallback, errorCallback) {
       return requestHelper.get({
-        url: apiEndpoint + "/v1/ping",
+        url: apiEndpoint + '/v1/ping',
         onSuccess: successCallback,
         onError: errorCallback
       });
-    }
+    };
 
     /**
-     * Authenticate the client with a user"s credentials
+     * Authenticate the client with a user's credentials
      *
      * @param {String} [username] username or email address (String)
      * @param {String} [password] password (String, UTF-8)
@@ -101,30 +102,30 @@ var GiantSwarm = (function () {
       });
 
       return requestHelper.post({
-        url: apiEndpoint + "/v1/user/" + username + "/login",
+        url: apiEndpoint + '/v1/user/' + username + '/login',
         onSuccess: function(data) {
           authToken = data.Id;
           successCallback(data);
         },
         onError: errorCallback,
         headers: this._headers(),
-        requestParams: {"password": base64encode(password)}
+        requestParams: {'password': base64encode(password)}
       });
-    }
+    };
 
     /**
      * Set authentication token, to be used as an alternative to authenticate().
-     * Parameter "token" can be of value null to make subsequent calls
+     * Parameter 'token' can be of value null to make subsequent calls
      * unauthenticated.
      *
      * @param {String} [token] Authentication token
      */
     this.setAuthToken = function(token) {
-      if (token !== null && typeof token !== "string") {
-        throw new UserException("Parameter 'token' must be of type String or null.");
+      if (token !== null && typeof token !== 'string') {
+        throw new UserException('Parameter "token" must be of type String or null.');
       }
       authToken = token;
-    }
+    };
 
     /**
      * Return the currently used authentication token
@@ -133,35 +134,35 @@ var GiantSwarm = (function () {
      */
     this.getAuthToken = function() {
       return authToken;
-    }
+    };
 
     /**
      * Get the Cluster ID
      */
     this._getClusterId = function() {
       return clusterId;
-    }
+    };
 
     /**
      * Sets the Cluster ID to be used with subsequent requests
      */
     this.setClusterId = function(cid) {
-      if (cid !== null && typeof cid !== "string") {
-        throw new UserException("Parameter 'cid' must be of type String or null.");
+      if (cid !== null && typeof cid !== 'string') {
+        throw new UserException('Parameter "cid" must be of type String or null.');
       }
       clusterId = cid;
-    }
+    };
 
     /**
      * Allows to set a callback function to be called when a 401 (Unauthorized) error is received
      */
     this.setUnauthorizedCallback = function(callback) {
-      if (typeof callback !== "function") {
-        throw new UserException("Parameter 'callback' must be of type function.");
+      if (typeof callback !== 'function') {
+        throw new UserException('Parameter "callback" must be of type function.');
       }
       requestHelper.unauthorizedCallback = callback;
       return callback;
-    }
+    };
 
     /**
      * Internal function to open a websocket connection
@@ -171,12 +172,12 @@ var GiantSwarm = (function () {
       this._validateStringParameters({
         uri: uri
       });
-      if (typeof postPayload !== "object") { throw new UserException("Parameter 'postPayload' must be an array"); }
-      if (typeof messageCallback !== "function") { throw new UserException("Parameter 'messageCallback' must be a function"); }
-      if (typeof createCallback !== "function") { throw new UserException("Parameter 'createCallback' must be a function"); }
-      if (errorCallback !== null && typeof errorCallback !== "function") { throw new UserException("errorCallback must be null or function"); }
+      if (typeof postPayload !== 'object') { throw new UserException('Parameter "postPayload" must be an array'); }
+      if (typeof messageCallback !== 'function') { throw new UserException('Parameter "messageCallback" must be a function'); }
+      if (typeof createCallback !== 'function') { throw new UserException('Parameter "createCallback" must be a function'); }
+      if (errorCallback !== null && typeof errorCallback !== 'function') { throw new UserException('errorCallback must be null or function'); }
       var headers = {
-        "Authorization": "giantswarm " + authToken
+        'Authorization': 'giantswarm ' + authToken
       };
 
       if (clusterId) {
@@ -186,7 +187,7 @@ var GiantSwarm = (function () {
       return requestHelper.post({
         url: apiEndpoint + uri,
         onSuccess: function(response) {
-          var url = websocketEndpoint + uri + "?p=" + response;
+          var url = websocketEndpoint + uri + '?p=' + response;
           var socket = new WebSocket(url);
           socket.onmessage = messageCallback;
           if (createCallback) { createCallback(socket); }
@@ -195,7 +196,7 @@ var GiantSwarm = (function () {
         requestParams: postPayload,
         headers: headers
       });
-    }
+    };
 
     /**
      * Get info about the authenticated user
@@ -205,12 +206,12 @@ var GiantSwarm = (function () {
      */
     this.user = function(successCallback, errorCallback) {
       return requestHelper.get({
-        url: apiEndpoint + "/v1/user/me",
+        url: apiEndpoint + '/v1/user/me',
         onSuccess: successCallback,
         onError: errorCallback,
-        headers: {"Authorization": "giantswarm " + authToken}
+        headers: {'Authorization': 'giantswarm ' + authToken}
       });
-    }
+    };
 
     /**
      * Get memberships of the authenticated user
@@ -220,12 +221,12 @@ var GiantSwarm = (function () {
      */
     this.memberships = function(successCallback, errorCallback) {
       return requestHelper.get({
-        url: apiEndpoint + "/v1/user/me/memberships",
+        url: apiEndpoint + '/v1/user/me/memberships',
         onSuccess: successCallback,
         onError: errorCallback,
-        headers: {"Authorization": "giantswarm " + authToken}
+        headers: {'Authorization': 'giantswarm ' + authToken}
       });
-    }
+    };
 
     /**
      * Get organization details
@@ -238,12 +239,12 @@ var GiantSwarm = (function () {
       this._validateStringParameters({organizationName: organizationName});
 
       return requestHelper.get({
-        url: apiEndpoint + "/v1/org/" + encodeURIComponent(organizationName),
+        url: apiEndpoint + '/v1/org/' + encodeURIComponent(organizationName),
         onSuccess: successCallback,
         onError: errorCallback,
-        headers: {"Authorization": "giantswarm " + authToken}
+        headers: {'Authorization': 'giantswarm ' + authToken}
       });
-    }
+    };
 
     this._processEnvironmentNames = function(response) {
       var names = [];
@@ -253,7 +254,7 @@ var GiantSwarm = (function () {
         }
       }
       return names;
-    }
+    };
 
     /**
      * Get array of environments of an organization
@@ -264,14 +265,14 @@ var GiantSwarm = (function () {
      */
     this.environments = function(organizationName, successCallback, errorCallback) {
       this._validateStringParameters({organizationName: organizationName});
-      if (typeof successCallback !== "function") { throw new UserException("successCallback must be given"); }
-      if (errorCallback !== null && typeof errorCallback !== "function") { throw new UserException("errorCallback must be null or function"); }
+      if (typeof successCallback !== 'function') { throw new UserException('successCallback must be given'); }
+      if (errorCallback !== null && typeof errorCallback !== 'function') { throw new UserException('errorCallback must be null or function'); }
 
-      var headers = { "Authorization": "giantswarm " + authToken };
+      var headers = { 'Authorization': 'giantswarm ' + authToken };
       if (clusterId) { headers[CLUSTER_ID_HEADER] = clusterId; }
 
       return requestHelper.get({
-        url: apiEndpoint + "/v1/org/" + encodeURIComponent(organizationName) + "/env/",
+        url: apiEndpoint + '/v1/org/' + encodeURIComponent(organizationName) + '/env/',
         onSuccess: function(response) {
           var names = this._processEnvironmentNames(response);
           successCallback(names);
@@ -279,14 +280,14 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: headers
       });
-    }
+    };
 
     this._headers = function() {
-      var headers = { "Authorization": "giantswarm " + authToken };
+      var headers = { 'Authorization': 'giantswarm ' + authToken };
       if (clusterId) { headers[CLUSTER_ID_HEADER] = clusterId; }
 
       return headers;
-    }
+    };
 
     /**
      * Get array of services in an environment
@@ -302,12 +303,12 @@ var GiantSwarm = (function () {
       });
 
       return requestHelper.get({
-        url: apiEndpoint + "/v1/org/" + encodeURIComponent(organizationName) + "/env/" + encodeURIComponent(environmentName) + "/service/",
+        url: apiEndpoint + '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/service/',
         onSuccess: successCallback,
         onError: errorCallback,
         headers: this._headers()
       });
-    }
+    };
 
     /**
      * Get Status and structure of an application
@@ -326,12 +327,12 @@ var GiantSwarm = (function () {
       });
 
       return requestHelper.get({
-        url: apiEndpoint + "/v1/org/" + encodeURIComponent(organizationName) + "/env/" + encodeURIComponent(environmentName) + "/service/" + encodeURIComponent(serviceName) + "/status",
+        url: apiEndpoint + '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/service/' + encodeURIComponent(serviceName) + '/status',
         onSuccess: successCallback,
         onError: errorCallback,
         headers: this._headers()
       });
-    }
+    };
 
     /**
      * Get configuration (swarm.json) of an application
@@ -350,12 +351,12 @@ var GiantSwarm = (function () {
       });
 
       return requestHelper.get({
-        url: apiEndpoint + "/v1/org/" + encodeURIComponent(organizationName) + "/env/" + encodeURIComponent(environmentName) + "/service/" + encodeURIComponent(serviceName) + "/definition",
+        url: apiEndpoint + '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/service/' + encodeURIComponent(serviceName) + '/definition',
         onSuccess: successCallback,
         onError: errorCallback,
         headers: this._headers()
       });
-    }
+    };
 
     /**
      * Start an application
@@ -373,7 +374,7 @@ var GiantSwarm = (function () {
         serviceName: serviceName
       });
 
-      var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/env/" + encodeURIComponent(environmentName) + "/service/" + encodeURIComponent(serviceName) + "/start";
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/service/' + encodeURIComponent(serviceName) + '/start';
 
       return requestHelper.post({
         url: apiEndpoint + uri,
@@ -381,7 +382,7 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: this._headers()
       });
-    }
+    };
 
     /**
      * Stop an application
@@ -399,7 +400,7 @@ var GiantSwarm = (function () {
         serviceName: serviceName
       });
 
-      var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/env/" + encodeURIComponent(environmentName) + "/service/" + encodeURIComponent(serviceName) + "/stop";
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName) + '/service/' + encodeURIComponent(serviceName) + '/stop';
 
       return requestHelper.post({
         url: apiEndpoint + uri,
@@ -407,7 +408,7 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: this._headers()
       });
-    }
+    };
 
    /**
      * Get status of a component
@@ -429,8 +430,8 @@ var GiantSwarm = (function () {
 
       var params = JSON.stringify({component: componentName});
 
-      var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/env/" + encodeURIComponent(environmentName);
-      uri += "/service/" + encodeURIComponent(serviceName) + "/component/status";
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName);
+      uri += '/service/' + encodeURIComponent(serviceName) + '/component/status';
 
       return requestHelper.post({
         url: apiEndpoint + uri,
@@ -439,7 +440,7 @@ var GiantSwarm = (function () {
         requestParams: params,
         headers: this._headers()
       });
-    }
+    };
 
     /**
      * Start a component
@@ -462,8 +463,8 @@ var GiantSwarm = (function () {
 
       var params = JSON.stringify({component: componentName});
 
-      var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/env/" + encodeURIComponent(environmentName);
-      uri += "/service/" + encodeURIComponent(serviceName) + "/component/start";
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName);
+      uri += '/service/' + encodeURIComponent(serviceName) + '/component/start';
 
       return requestHelper.post({
         url: apiEndpoint + uri,
@@ -472,7 +473,7 @@ var GiantSwarm = (function () {
         requestParams: params,
         headers: this._headers()
       });
-    }
+    };
 
     /**
      * Stop a component
@@ -495,8 +496,8 @@ var GiantSwarm = (function () {
 
       var params = JSON.stringify({component: componentName});
 
-      var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/env/" + encodeURIComponent(environmentName);
-      uri += "/service/" + encodeURIComponent(serviceName) + "/component/stop";
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/env/' + encodeURIComponent(environmentName);
+      uri += '/service/' + encodeURIComponent(serviceName) + '/component/stop';
 
       return requestHelper.post({
         url: apiEndpoint + uri,
@@ -505,7 +506,7 @@ var GiantSwarm = (function () {
         requestParams: params,
         headers: this._headers()
       });
-    }
+    };
 
     /**
      * Get statistics for an instance
@@ -520,7 +521,7 @@ var GiantSwarm = (function () {
         instanceId: instanceId
       });
 
-      var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/instance/" + encodeURIComponent(instanceId) + "/stats";
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/instance/' + encodeURIComponent(instanceId) + '/stats';
 
       return requestHelper.post({
         url: apiEndpoint + uri,
@@ -528,7 +529,7 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: this._headers()
       });
-    }
+    };
 
     /**
      * Get logs for an instance
@@ -546,15 +547,15 @@ var GiantSwarm = (function () {
 
       if (numLines === null) { numLines = 10; }
 
-      if (typeof numLines !== "number" || isNaN(numLines) || parseInt(Number(numLines)) !== numLines
+      if (typeof numLines !== 'number' || isNaN(numLines) || parseInt(Number(numLines)) !== numLines
         || isNaN(parseInt(numLines, 10)) || numLines <= 0) {
-        throw new UserException("Parameter 'numLines' must be a positive integer");
+        throw new UserException('Parameter "numLines" must be a positive integer');
       }
       var params = {};
       if (numLines !== null) {
         params.t = numLines;
       }
-      var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/instance/" + encodeURIComponent(instanceId) + "/logs";
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/instance/' + encodeURIComponent(instanceId) + '/logs';
 
       return requestHelper.get({
         url: apiEndpoint + uri,
@@ -563,7 +564,7 @@ var GiantSwarm = (function () {
         requestParams: params,
         headers: this._headers()
       });
-    }
+    };
 
     /**
      * Create a websocket connection to stream logs from instances
@@ -578,18 +579,18 @@ var GiantSwarm = (function () {
       this._validateStringParameters({
         organizationName: organizationName
       });
-      if (typeof instanceIds !== "object") { throw new UserException("Parameter 'instanceIds' must be an array"); }
-      if (typeof messageCallback !== "function") { throw new UserException("Parameter 'messageCallback' must be a function"); }
-      if (typeof createCallback !== "function") { throw new UserException("Parameter 'createCallback' must be a function"); }
-      if (errorCallback !== null && typeof errorCallback !== "function") { throw new UserException("errorCallback must be null or function"); }
-      var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/stream/logs";
+      if (typeof instanceIds !== 'object') { throw new UserException('Parameter "instanceIds" must be an array'); }
+      if (typeof messageCallback !== 'function') { throw new UserException('Parameter "messageCallback" must be a function'); }
+      if (typeof createCallback !== 'function') { throw new UserException('Parameter "createCallback" must be a function'); }
+      if (errorCallback !== null && typeof errorCallback !== 'function') { throw new UserException('errorCallback must be null or function'); }
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/stream/logs';
       var postPayload = {instances: instanceIds};
       this._postForWebSocket(uri,
         postPayload,
         messageCallback,
         createCallback,
         errorCallback);
-    }
+    };
 
     /**
      * Create a websocket connection to stream statistics from instances
@@ -606,17 +607,17 @@ var GiantSwarm = (function () {
       this._validateStringParameters({
         organizationName: organizationName
       });
-      if (typeof instanceIds !== "object") { throw new UserException("Parameter 'instanceIds' must be an array"); }
-      if (typeof interval !== "number") { throw new UserException("Parameter 'interval' must be a number"); }
-      if (interval < 2) { throw new UserException("Value or parameter 'interval' must be min 2"); }
-      var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/stream/stats";
+      if (typeof instanceIds !== 'object') { throw new UserException('Parameter "instanceIds" must be an array'); }
+      if (typeof interval !== 'number') { throw new UserException('Parameter "interval" must be a number'); }
+      if (interval < 2) { throw new UserException('Value or parameter "interval" must be min 2'); }
+      var uri = '/v1/org/' + encodeURIComponent(organizationName) + '/stream/stats';
       var postPayload = {instances: instanceIds, interval: interval};
       this._postForWebSocket(uri,
         postPayload,
         messageCallback,
         createCallback,
         errorCallback);
-    }
+    };
 
     /**
      * Expire the auth token currently used
@@ -625,24 +626,24 @@ var GiantSwarm = (function () {
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
     this.logout = function(successCallback, errorCallback) {
-      if (!successCallback) { throw new UserException("Parameter successCallback must be given"); }
-      if (typeof successCallback !== "function") { throw new UserException("Parameter successCallback must be of type function"); }
-      if (errorCallback !== null && typeof errorCallback !== "function") { throw new UserException("errorCallback must be null or function"); }
+      if (!successCallback) { throw new UserException('Parameter successCallback must be given'); }
+      if (typeof successCallback !== 'function') { throw new UserException('Parameter successCallback must be of type function'); }
+      if (errorCallback !== null && typeof errorCallback !== 'function') { throw new UserException('errorCallback must be null or function'); }
 
       return requestHelper.post({
-        url: apiEndpoint + "/v1/token/logout",
+        url: apiEndpoint + '/v1/token/logout',
         onSuccess: successCallback,
         onError: errorCallback,
         headers: this._headers()
       });
-    }
+    };
 
     /**
      * Return true if the client is authenticated, otherwise return false
      */
     this.isAuthenticated = function(responseCallback) {
-      if (!responseCallback) { throw new UserException("Parameter responseCallback must be given"); }
-      if (typeof responseCallback !== "function") { throw new UserException("Parameter responseCallback must be of type function"); }
+      if (!responseCallback) { throw new UserException('Parameter responseCallback must be given'); }
+      if (typeof responseCallback !== 'function') { throw new UserException('Parameter responseCallback must be of type function'); }
       var answer = false;
       if (authToken === null) {
         responseCallback(answer);
@@ -656,15 +657,14 @@ var GiantSwarm = (function () {
           responseCallback(answer);
         });
       }
-    }
-
+    };
   };
 
 })();
 
-if (typeof window !== "undefined") {
+if (typeof window !== 'undefined') {
   window.GiantSwarm = GiantSwarm;
 }
-if (typeof module !== "undefined") {
+if (typeof module !== 'undefined') {
   module.exports = GiantSwarm;
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,11 +15,26 @@ var GiantSwarm = (function () {
   }
 
   return function(){
-    var requestHelper = new RequestHelper();
+    this._generateRequestID = function() {
+      // I just picked something from the internet:
+      // http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
+      //
+      // It has caveats but for our purposes should be good enough.
+
+      return ('xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+        return v.toString(16);
+      }));
+    }
+
+    var requestID = this._generateRequestID();
+    var requestHelper = new RequestHelper(requestID);
     var authToken = null;
     var clusterId = null;
     var apiEndpoint = "https://api.giantswarm.io";
     var websocketEndpoint = "wss://api.giantswarm.io";
+
+
 
     // to be thrown in case of bad parameters/arguments/values given
     this.UserException = function(message) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,7 @@
+"use strict";
 var RequestHelper = require("./request_helper");
 var Base64 = require("js-base64").Base64;
+var UserException = require('./user_exception.js')
 
 if (typeof WebSocket === "undefined") {
   var WebSocket = require("ws");
@@ -8,8 +10,6 @@ if (typeof WebSocket === "undefined") {
 var uuid = require("node-uuid");
 
 var GiantSwarm = (function () {
-  "use strict";
-
   var CLUSTER_ID_HEADER = "X-Giant-Swarm-ClusterID";
 
   var base64encode = function (str) {
@@ -24,25 +24,14 @@ var GiantSwarm = (function () {
     var apiEndpoint = "https://api.giantswarm.io";
     var websocketEndpoint = "wss://api.giantswarm.io";
 
-
-
-    // to be thrown in case of bad parameters/arguments/values given
-    this.UserException = function(message) {
-      this.message = message;
-      this.name = "UserException";
-      this.toString = function(){
-        return this.name + ": " + this.message;
-      };
-    }
-
     // simplify validation of string parameters for internal methods
     this._validateStringParameters = function(parameters) {
       for (var name in parameters) {
         if (!parameters[name]) {
-          throw new this.UserException("Parameter '" + name + "' must be given");
+          throw new UserException("Parameter '" + name + "' must be given");
         }
         if (typeof parameters[name] !== "string") {
-          throw new this.UserException("Parameter '" + name + "' must be of type string");
+          throw new UserException("Parameter '" + name + "' must be of type string");
         }
       }
     }
@@ -132,7 +121,7 @@ var GiantSwarm = (function () {
      */
     this.setAuthToken = function(token) {
       if (token !== null && typeof token !== "string") {
-        throw new this.UserException("Parameter 'token' must be of type String or null.");
+        throw new UserException("Parameter 'token' must be of type String or null.");
       }
       authToken = token;
     }
@@ -158,7 +147,7 @@ var GiantSwarm = (function () {
      */
     this.setClusterId = function(cid) {
       if (cid !== null && typeof cid !== "string") {
-        throw new this.UserException("Parameter 'cid' must be of type String or null.");
+        throw new UserException("Parameter 'cid' must be of type String or null.");
       }
       clusterId = cid;
     }
@@ -168,7 +157,7 @@ var GiantSwarm = (function () {
      */
     this.setUnauthorizedCallback = function(callback) {
       if (typeof callback !== "function") {
-        throw new this.UserException("Parameter 'callback' must be of type function.");
+        throw new UserException("Parameter 'callback' must be of type function.");
       }
       requestHelper.unauthorizedCallback = callback;
       return callback;
@@ -182,10 +171,10 @@ var GiantSwarm = (function () {
       this._validateStringParameters({
         uri: uri
       });
-      if (typeof postPayload !== "object") { throw new this.UserException("Parameter 'postPayload' must be an array"); }
-      if (typeof messageCallback !== "function") { throw new this.UserException("Parameter 'messageCallback' must be a function"); }
-      if (typeof createCallback !== "function") { throw new this.UserException("Parameter 'createCallback' must be a function"); }
-      if (errorCallback !== null && typeof errorCallback !== "function") { throw new this.UserException("errorCallback must be null or function"); }
+      if (typeof postPayload !== "object") { throw new UserException("Parameter 'postPayload' must be an array"); }
+      if (typeof messageCallback !== "function") { throw new UserException("Parameter 'messageCallback' must be a function"); }
+      if (typeof createCallback !== "function") { throw new UserException("Parameter 'createCallback' must be a function"); }
+      if (errorCallback !== null && typeof errorCallback !== "function") { throw new UserException("errorCallback must be null or function"); }
       var headers = {
         "Authorization": "giantswarm " + authToken
       };
@@ -275,8 +264,8 @@ var GiantSwarm = (function () {
      */
     this.environments = function(organizationName, successCallback, errorCallback) {
       this._validateStringParameters({organizationName: organizationName});
-      if (typeof successCallback !== "function") { throw new this.UserException("successCallback must be given"); }
-      if (errorCallback !== null && typeof errorCallback !== "function") { throw new this.UserException("errorCallback must be null or function"); }
+      if (typeof successCallback !== "function") { throw new UserException("successCallback must be given"); }
+      if (errorCallback !== null && typeof errorCallback !== "function") { throw new UserException("errorCallback must be null or function"); }
 
       var headers = { "Authorization": "giantswarm " + authToken };
       if (clusterId) { headers[CLUSTER_ID_HEADER] = clusterId; }
@@ -559,7 +548,7 @@ var GiantSwarm = (function () {
 
       if (typeof numLines !== "number" || isNaN(numLines) || parseInt(Number(numLines)) !== numLines
         || isNaN(parseInt(numLines, 10)) || numLines <= 0) {
-        throw new this.UserException("Parameter 'numLines' must be a positive integer");
+        throw new UserException("Parameter 'numLines' must be a positive integer");
       }
       var params = {};
       if (numLines !== null) {
@@ -589,10 +578,10 @@ var GiantSwarm = (function () {
       this._validateStringParameters({
         organizationName: organizationName
       });
-      if (typeof instanceIds !== "object") { throw new this.UserException("Parameter 'instanceIds' must be an array"); }
-      if (typeof messageCallback !== "function") { throw new this.UserException("Parameter 'messageCallback' must be a function"); }
-      if (typeof createCallback !== "function") { throw new this.UserException("Parameter 'createCallback' must be a function"); }
-      if (errorCallback !== null && typeof errorCallback !== "function") { throw new this.UserException("errorCallback must be null or function"); }
+      if (typeof instanceIds !== "object") { throw new UserException("Parameter 'instanceIds' must be an array"); }
+      if (typeof messageCallback !== "function") { throw new UserException("Parameter 'messageCallback' must be a function"); }
+      if (typeof createCallback !== "function") { throw new UserException("Parameter 'createCallback' must be a function"); }
+      if (errorCallback !== null && typeof errorCallback !== "function") { throw new UserException("errorCallback must be null or function"); }
       var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/stream/logs";
       var postPayload = {instances: instanceIds};
       this._postForWebSocket(uri,
@@ -617,9 +606,9 @@ var GiantSwarm = (function () {
       this._validateStringParameters({
         organizationName: organizationName
       });
-      if (typeof instanceIds !== "object") { throw new this.UserException("Parameter 'instanceIds' must be an array"); }
-      if (typeof interval !== "number") { throw new this.UserException("Parameter 'interval' must be a number"); }
-      if (interval < 2) { throw new this.UserException("Value or parameter 'interval' must be min 2"); }
+      if (typeof instanceIds !== "object") { throw new UserException("Parameter 'instanceIds' must be an array"); }
+      if (typeof interval !== "number") { throw new UserException("Parameter 'interval' must be a number"); }
+      if (interval < 2) { throw new UserException("Value or parameter 'interval' must be min 2"); }
       var uri = "/v1/org/" + encodeURIComponent(organizationName) + "/stream/stats";
       var postPayload = {instances: instanceIds, interval: interval};
       this._postForWebSocket(uri,
@@ -636,9 +625,9 @@ var GiantSwarm = (function () {
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
     this.logout = function(successCallback, errorCallback) {
-      if (!successCallback) { throw new this.UserException("Parameter successCallback must be given"); }
-      if (typeof successCallback !== "function") { throw new this.UserException("Parameter successCallback must be of type function"); }
-      if (errorCallback !== null && typeof errorCallback !== "function") { throw new this.UserException("errorCallback must be null or function"); }
+      if (!successCallback) { throw new UserException("Parameter successCallback must be given"); }
+      if (typeof successCallback !== "function") { throw new UserException("Parameter successCallback must be of type function"); }
+      if (errorCallback !== null && typeof errorCallback !== "function") { throw new UserException("errorCallback must be null or function"); }
 
       return requestHelper.post({
         url: apiEndpoint + "/v1/token/logout",
@@ -652,8 +641,8 @@ var GiantSwarm = (function () {
      * Return true if the client is authenticated, otherwise return false
      */
     this.isAuthenticated = function(responseCallback) {
-      if (!responseCallback) { throw new this.UserException("Parameter responseCallback must be given"); }
-      if (typeof responseCallback !== "function") { throw new this.UserException("Parameter responseCallback must be of type function"); }
+      if (!responseCallback) { throw new UserException("Parameter responseCallback must be given"); }
+      if (typeof responseCallback !== "function") { throw new UserException("Parameter responseCallback must be of type function"); }
       var answer = false;
       if (authToken === null) {
         responseCallback(answer);

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,4 @@
-var requestHelper = require("./request_helper");
+var RequestHelper = require("./request_helper");
 var Base64 = require("js-base64").Base64;
 
 if (typeof WebSocket === "undefined") {
@@ -8,30 +8,30 @@ if (typeof WebSocket === "undefined") {
 var GiantSwarm = (function () {
   "use strict";
 
-  var authToken = null;
-  var clusterId = null;
-  var apiEndpoint = "https://api.giantswarm.io";
-  var websocketEndpoint = "wss://api.giantswarm.io";
-
   var CLUSTER_ID_HEADER = "X-Giant-Swarm-ClusterID";
 
   var base64encode = function (str) {
     return Base64.encode(str);
   }
 
-  return {
+  return function(){
+    var requestHelper = new RequestHelper();
+    var authToken = null;
+    var clusterId = null;
+    var apiEndpoint = "https://api.giantswarm.io";
+    var websocketEndpoint = "wss://api.giantswarm.io";
 
     // to be thrown in case of bad parameters/arguments/values given
-    UserException: function(message) {
+    this.UserException = function(message) {
       this.message = message;
       this.name = "UserException";
       this.toString = function(){
         return this.name + ": " + this.message;
       };
-    },
+    }
 
     // simplify validation of string parameters for internal methods
-    _validateStringParameters: function(parameters) {
+    this._validateStringParameters = function(parameters) {
       for (var name in parameters) {
         if (!parameters[name]) {
           throw new this.UserException("Parameter '" + name + "' must be given");
@@ -40,13 +40,13 @@ var GiantSwarm = (function () {
           throw new this.UserException("Parameter '" + name + "' must be of type string");
         }
       }
-    },
+    }
 
     // Internal method to get the websocketEndpoint
     // mainly to make setApiEndpoint testable
-    _getWebsocketEndpoint: function() {
+    this._getWebsocketEndpoint = function() {
       return websocketEndpoint;
-    },
+    }
 
     /**
      * Allows the user to overwrite the default API endpoint
@@ -54,17 +54,29 @@ var GiantSwarm = (function () {
      *
      * @param {String} [url] The URL to use as endpoint, without trailing slash
      */
-    setApiEndpoint: function(url) {
+    this.setApiEndpoint = function(url) {
       this._validateStringParameters({url: url});
       apiEndpoint = url;
       var wsurl = url.replace("http://", "ws://");
       wsurl = wsurl.replace("https://", "wss://");
       websocketEndpoint = wsurl;
-    },
+    }
 
-    getApiEndpoint: function(url) {
+    this.getApiEndpoint = function(url) {
       return apiEndpoint;
-    },
+    }
+
+    /**
+     * Allow the user to set the activity they are performing with this client
+     * will be used by all subsequent API calls for the X-Giant-Swarm-Activity
+     * header
+     *
+     * @param {String} [activityName] The name of the activity that should be sent
+     */
+    this.setActivity = function(activityName) {
+      this._validateStringParameters({activityName: activityName});
+      requestHelper.setActivity(activityName);
+    }
 
     /**
      * Check the availability of the API
@@ -72,13 +84,13 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback to be called in case of success, no arguments
      * @param {Function} [errorCallback] Callback to be called in case of an error, error object as argument
      */
-    ping: function(successCallback, errorCallback) {
+    this.ping = function(successCallback, errorCallback) {
       return requestHelper.get({
         url: apiEndpoint + "/v1/ping",
         onSuccess: successCallback,
         onError: errorCallback
       });
-    },
+    }
 
     /**
      * Authenticate the client with a user"s credentials
@@ -88,7 +100,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Optional callback to be called in case of success, no arguments
      * @param {Function} [errorCallback] Optional callback to be callled in case of an error, error object as argument
      */
-    authenticate: function(username, password, successCallback, errorCallback) {
+    this.authenticate = function(username, password, successCallback, errorCallback) {
       this._validateStringParameters({
         username: username,
         password: password
@@ -104,7 +116,7 @@ var GiantSwarm = (function () {
         headers: this._headers(),
         requestParams: {"password": base64encode(password)}
       });
-    },
+    }
 
     /**
      * Set authentication token, to be used as an alternative to authenticate().
@@ -113,55 +125,55 @@ var GiantSwarm = (function () {
      *
      * @param {String} [token] Authentication token
      */
-    setAuthToken: function(token) {
+    this.setAuthToken = function(token) {
       if (token !== null && typeof token !== "string") {
         throw new this.UserException("Parameter 'token' must be of type String or null.");
       }
       authToken = token;
-    },
+    }
 
     /**
      * Return the currently used authentication token
      *
      * @returns {String} Currently used authentication token, might be null.
      */
-    getAuthToken: function() {
+    this.getAuthToken = function() {
       return authToken;
-    },
+    }
 
     /**
      * Get the Cluster ID
      */
-    _getClusterId: function() {
+    this._getClusterId = function() {
       return clusterId;
-    },
+    }
 
     /**
      * Sets the Cluster ID to be used with subsequent requests
      */
-    setClusterId: function(cid) {
+    this.setClusterId = function(cid) {
       if (cid !== null && typeof cid !== "string") {
         throw new this.UserException("Parameter 'cid' must be of type String or null.");
       }
       clusterId = cid;
-    },
+    }
 
     /**
      * Allows to set a callback function to be called when a 401 (Unauthorized) error is received
      */
-    setUnauthorizedCallback: function(callback) {
+    this.setUnauthorizedCallback = function(callback) {
       if (typeof callback !== "function") {
         throw new this.UserException("Parameter 'callback' must be of type function.");
       }
       requestHelper.unauthorizedCallback = callback;
       return callback;
-    },
+    }
 
     /**
      * Internal function to open a websocket connection
      * as a result of a post request
      */
-    _postForWebSocket: function(uri, postPayload, messageCallback, createCallback, errorCallback) {
+    this._postForWebSocket = function(uri, postPayload, messageCallback, createCallback, errorCallback) {
       this._validateStringParameters({
         uri: uri
       });
@@ -189,7 +201,7 @@ var GiantSwarm = (function () {
         requestParams: postPayload,
         headers: headers
       });
-    },
+    }
 
     /**
      * Get info about the authenticated user
@@ -197,14 +209,14 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the user info object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    user: function(successCallback, errorCallback) {
+    this.user = function(successCallback, errorCallback) {
       return requestHelper.get({
         url: apiEndpoint + "/v1/user/me",
         onSuccess: successCallback,
         onError: errorCallback,
         headers: {"Authorization": "giantswarm " + authToken}
       });
-    },
+    }
 
     /**
      * Get memberships of the authenticated user
@@ -212,14 +224,14 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the array of organization names as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    memberships: function(successCallback, errorCallback) {
+    this.memberships = function(successCallback, errorCallback) {
       return requestHelper.get({
         url: apiEndpoint + "/v1/user/me/memberships",
         onSuccess: successCallback,
         onError: errorCallback,
         headers: {"Authorization": "giantswarm " + authToken}
       });
-    },
+    }
 
     /**
      * Get organization details
@@ -228,7 +240,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the organization object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    organization: function(organizationName, successCallback, errorCallback) {
+    this.organization = function(organizationName, successCallback, errorCallback) {
       this._validateStringParameters({organizationName: organizationName});
 
       return requestHelper.get({
@@ -237,9 +249,9 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: {"Authorization": "giantswarm " + authToken}
       });
-    },
+    }
 
-    _processEnvironmentNames: function(response) {
+    this._processEnvironmentNames = function(response) {
       var names = [];
       if (response.environments) {
         for (var i in response.environments) {
@@ -247,7 +259,7 @@ var GiantSwarm = (function () {
         }
       }
       return names;
-    },
+    }
 
     /**
      * Get array of environments of an organization
@@ -256,7 +268,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the array of environments as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    environments: function(organizationName, successCallback, errorCallback) {
+    this.environments = function(organizationName, successCallback, errorCallback) {
       this._validateStringParameters({organizationName: organizationName});
       if (typeof successCallback !== "function") { throw new this.UserException("successCallback must be given"); }
       if (errorCallback !== null && typeof errorCallback !== "function") { throw new this.UserException("errorCallback must be null or function"); }
@@ -273,14 +285,14 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: headers
       });
-    },
+    }
 
-    _headers: function() {
+    this._headers = function() {
       var headers = { "Authorization": "giantswarm " + authToken };
       if (clusterId) { headers[CLUSTER_ID_HEADER] = clusterId; }
 
       return headers;
-    },
+    }
 
     /**
      * Get array of services in an environment
@@ -289,7 +301,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the array of services as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    services: function(organizationName, environmentName, successCallback, errorCallback) {
+    this.services = function(organizationName, environmentName, successCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName,
         environmentName: environmentName
@@ -301,7 +313,7 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: this._headers()
       });
-    },
+    }
 
     /**
      * Get Status and structure of an application
@@ -312,7 +324,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the status information object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    serviceStatus: function(organizationName, environmentName, serviceName, successCallback, errorCallback) {
+    this.serviceStatus = function(organizationName, environmentName, serviceName, successCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName,
         environmentName: environmentName,
@@ -325,7 +337,7 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: this._headers()
       });
-    },
+    }
 
     /**
      * Get configuration (swarm.json) of an application
@@ -336,7 +348,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the config information object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    serviceDefinition: function(organizationName, environmentName, serviceName, successCallback, errorCallback) {
+    this.serviceDefinition = function(organizationName, environmentName, serviceName, successCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName,
         environmentName: environmentName,
@@ -349,7 +361,7 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: this._headers()
       });
-    },
+    }
 
     /**
      * Start an application
@@ -360,7 +372,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the config information object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    startService: function(organizationName, environmentName, serviceName, successCallback, errorCallback) {
+    this.startService = function(organizationName, environmentName, serviceName, successCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName,
         environmentName: environmentName,
@@ -375,7 +387,7 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: this._headers()
       });
-    },
+    }
 
     /**
      * Stop an application
@@ -386,7 +398,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the config information object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    stopService: function(organizationName, environmentName, serviceName, successCallback, errorCallback) {
+    this.stopService = function(organizationName, environmentName, serviceName, successCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName,
         environmentName: environmentName,
@@ -401,7 +413,7 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: this._headers()
       });
-    },
+    }
 
    /**
      * Get status of a component
@@ -413,7 +425,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the status information object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    componentStatus: function(organizationName, environmentName, serviceName, componentName, successCallback, errorCallback) {
+    this.componentStatus = function(organizationName, environmentName, serviceName, componentName, successCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName,
         environmentName: environmentName,
@@ -433,7 +445,7 @@ var GiantSwarm = (function () {
         requestParams: params,
         headers: this._headers()
       });
-    },
+    }
 
     /**
      * Start a component
@@ -446,7 +458,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the config information object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    startComponent: function(organizationName, environmentName, serviceName, componentName, successCallback, errorCallback) {
+    this.startComponent = function(organizationName, environmentName, serviceName, componentName, successCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName,
         environmentName: environmentName,
@@ -466,7 +478,7 @@ var GiantSwarm = (function () {
         requestParams: params,
         headers: this._headers()
       });
-    },
+    }
 
     /**
      * Stop a component
@@ -479,7 +491,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the config information object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    stopComponent: function(organizationName, environmentName, serviceName, componentName, successCallback, errorCallback) {
+    this.stopComponent = function(organizationName, environmentName, serviceName, componentName, successCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName,
         environmentName: environmentName,
@@ -499,7 +511,7 @@ var GiantSwarm = (function () {
         requestParams: params,
         headers: this._headers()
       });
-    },
+    }
 
     /**
      * Get statistics for an instance
@@ -508,7 +520,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the statistics object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    instanceStats: function(organizationName, instanceId, successCallback, errorCallback) {
+    this.instanceStats = function(organizationName, instanceId, successCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName,
         instanceId: instanceId
@@ -522,7 +534,7 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: this._headers()
       });
-    },
+    }
 
     /**
      * Get logs for an instance
@@ -532,7 +544,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback receiving the statistics object as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    instanceLogs: function(organizationName, instanceId, numLines, successCallback, errorCallback) {
+    this.instanceLogs = function(organizationName, instanceId, numLines, successCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName,
         instanceId: instanceId
@@ -557,7 +569,7 @@ var GiantSwarm = (function () {
         requestParams: params,
         headers: this._headers()
       });
-    },
+    }
 
     /**
      * Create a websocket connection to stream logs from instances
@@ -568,7 +580,7 @@ var GiantSwarm = (function () {
      * @param {Function} [createCallback] Callback to call on creation of the websocket object
      * @param {Function} [errorCallback] Callback to call in case an error occurs during initialization
      */
-    streamLogs: function(organizationName, instanceIds, messageCallback, createCallback, errorCallback) {
+    this.streamLogs = function(organizationName, instanceIds, messageCallback, createCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName
       });
@@ -583,7 +595,7 @@ var GiantSwarm = (function () {
         messageCallback,
         createCallback,
         errorCallback);
-    },
+    }
 
     /**
      * Create a websocket connection to stream statistics from instances
@@ -595,7 +607,7 @@ var GiantSwarm = (function () {
      * @param {Function} [createCallback] Callback to call on creation of the websocket object
      * @param {Function} [errorCallback] Callback to call in case an error occurs during initialization
      */
-    streamStats: function(organizationName, instanceIds, interval, messageCallback,
+    this.streamStats = function(organizationName, instanceIds, interval, messageCallback,
       createCallback, errorCallback) {
       this._validateStringParameters({
         organizationName: organizationName
@@ -610,7 +622,7 @@ var GiantSwarm = (function () {
         messageCallback,
         createCallback,
         errorCallback);
-    },
+    }
 
     /**
      * Expire the auth token currently used
@@ -618,7 +630,7 @@ var GiantSwarm = (function () {
      * @param {Function} [successCallback] Callback to be called in case of success, gets response data as argument
      * @param {Function} [errorCallback] Optional callback to be called in case of an error, error object as argument
      */
-    logout: function(successCallback, errorCallback) {
+    this.logout = function(successCallback, errorCallback) {
       if (!successCallback) { throw new this.UserException("Parameter successCallback must be given"); }
       if (typeof successCallback !== "function") { throw new this.UserException("Parameter successCallback must be of type function"); }
       if (errorCallback !== null && typeof errorCallback !== "function") { throw new this.UserException("errorCallback must be null or function"); }
@@ -629,12 +641,12 @@ var GiantSwarm = (function () {
         onError: errorCallback,
         headers: this._headers()
       });
-    },
+    }
 
     /**
      * Return true if the client is authenticated, otherwise return false
      */
-    isAuthenticated: function(responseCallback) {
+    this.isAuthenticated = function(responseCallback) {
       if (!responseCallback) { throw new this.UserException("Parameter responseCallback must be given"); }
       if (typeof responseCallback !== "function") { throw new this.UserException("Parameter responseCallback must be of type function"); }
       var answer = false;

--- a/lib/request_helper.js
+++ b/lib/request_helper.js
@@ -1,13 +1,17 @@
-agent = require('superagent');
-_ = require('underscore')
+var agent = require('superagent');
+var _     = require('underscore');
 
-var requestHelper = (function() {
-  return {
-    unauthorizedCallback: function() {
+var ACTIVITY_HEADER = "X-Giant-Swarm-Activity";
+
+var RequestHelper = (function() {
+  return function(){
+    var currentActivity = null;
+
+    this.unauthorizedCallback = function() {
       // noop
-    },
+    }
 
-    _handleResponses: function(params) {
+    this._handleResponses = function(params) {
       var onError   = params.onError;
       var onSuccess = params.onSuccess;
       var error     = params.error;
@@ -46,26 +50,30 @@ var requestHelper = (function() {
       if (response.ok) { onSuccess(response.body.data); return }
       if (response.unauthorized) { this.unauthorizedCallback() }
       if (error) { onError(error); return }
-    },
+    }
 
-    _validateOptionalCallback: function(callback, errorMessage) {
+    this._validateOptionalCallback = function(callback, errorMessage) {
       if (callback !== null && typeof callback !== 'function') throw new this.UserException(errorMessage);
-    },
+    }
 
-    _validateRequiredCallback: function(callback, errorMessage) {
+    this._validateRequiredCallback = function(callback, errorMessage) {
       if (typeof callback !== 'function') throw new this.UserException(errorMessage);
-    },
+    }
 
-    _processParams: function(params) {
+    this._processParams = function(params) {
       params.headers = params.headers || {};
       params.requestParams = params.requestParams;
+
+      if (currentActivity) {
+        params.headers[ACTIVITY_HEADER] = currentActivity;
+      }
 
       this._validateOptionalCallback(params.onError,   'onError must be null or a function');
       this._validateRequiredCallback(params.onSuccess, 'an onSuccess callback must be given');
       return params;
-    },
+    }
 
-    _finish: function(agent, params) {
+    this._finish = function(agent, params) {
       return agent.set(params.headers)
         .end(function(error, response){
           this._handleResponses({
@@ -78,7 +86,7 @@ var requestHelper = (function() {
     },
 
     // Checks for the presence of a nested key
-    _checkNested: function(obj /*, level1, level2, ... levelN*/) {
+    this._checkNested = function(obj /*, level1, level2, ... levelN*/) {
       var args = Array.prototype.slice.call(arguments, 1);
 
       for (var i = 0; i < args.length; i++) {
@@ -88,18 +96,22 @@ var requestHelper = (function() {
         obj = obj[args[i]];
       }
       return true;
-    },
+    }
 
-    get: function(params) {
+    this.setActivity = function(activityName) {
+      currentActivity = activityName;
+    }
+
+    this.get = function(params) {
       params = this._processParams(params);
       return this._finish(agent.get(params.url).query(params.requestParams), params);
-    },
+    }
 
-    post: function(params) {
+    this.post = function(params) {
       params = this._processParams(params);
       return this._finish(agent.post(params.url).send(params.requestParams), params);
     }
   };
 })();
 
-module.exports = requestHelper;
+module.exports = RequestHelper;

--- a/lib/request_helper.js
+++ b/lib/request_helper.js
@@ -1,123 +1,120 @@
-var UserException = require('./user_exception.js')
+var UserException = require('./user_exception.js');
 var agent = require('superagent');
-var _     = require('underscore');
+var _ = require('underscore');
 
-var ACTIVITY_HEADER = "X-Giant-Swarm-Activity";
-var REQUEST_ID_HEADER = "X-Request-ID";
+var ACTIVITY_HEADER = 'X-Giant-Swarm-Activity';
+var REQUEST_ID_HEADER = 'X-Request-ID';
 
-var RequestHelper = (function(requestID) {
-  return function(requestID){
-    var currentActivity = null;
-    var requestID = requestID;
+var RequestHelper = function(requestID){
+  var currentActivity = null;
 
-    this.unauthorizedCallback = function() {
-      // noop
-    }
-
-    this._handleResponses = function(params) {
-      var onError   = params.onError;
-      var onSuccess = params.onSuccess;
-      var error     = params.error;
-      var response  = params.response;
-
-      // Slime in the ok and body.data properties
-      // for the ping api call.
-      if(response.text === '"OK"') {
-        response.ok = true
-        response.body = {}
-        response.body.data = "OK"
-      }
-
-      // Slime in the ok and body.data properties
-      // for the instance logs api call.
-      if(! response.body && typeof response.text === "string" && ! error) {
-        response.ok = true
-        response.body = {}
-        response.body.data = response.text
-      }
-
-      // Convert 0001-01-01T00:00:00Z to null
-      if(this._checkNested(response, 'body', 'data', 'components')) {
-        // If the response contains components,
-        // loop over them and check for and replace the null date
-
-        _.each(response.body.data.components, function(component){
-          _.each(component.instances, function(instance){
-            if(instance.create_date === "0001-01-01T00:00:00Z") {
-              instance.create_date = null;
-            }
-          })
-        })
-      }
-
-      if (response.ok) { onSuccess(response.body.data); return }
-      if (response.unauthorized) { this.unauthorizedCallback() }
-      if (error) { onError(error); return }
-    }
-
-    this._validateOptionalCallback = function(callback, errorMessage) {
-      if (callback !== null && typeof callback !== 'function') throw new UserException(errorMessage);
-    }
-
-    this._validateRequiredCallback = function(callback, errorMessage) {
-      if (typeof callback !== 'function') throw new UserException(errorMessage);
-    }
-
-    this._processParams = function(params) {
-      params.headers = params.headers || {};
-      params.requestParams = params.requestParams;
-
-      if (currentActivity) {
-        params.headers[ACTIVITY_HEADER] = currentActivity;
-      }
-
-      params.headers[REQUEST_ID_HEADER] = requestID;
-
-      this._validateRequiredCallback(params.onSuccess, 'an onSuccess callback must be given and it must be a function');
-      this._validateOptionalCallback(params.onError,   'onError must be null or a function');
-
-      return params;
-    }
-
-    this._finish = function(agent, params) {
-      return agent.set(params.headers)
-        .end(function(error, response){
-          this._handleResponses({
-            error: error,
-            response: response,
-            onSuccess: params.onSuccess,
-            onError: params.onError
-          })
-        }.bind(this));
-    },
-
-    // Checks for the presence of a nested key
-    this._checkNested = function(obj /*, level1, level2, ... levelN*/) {
-      var args = Array.prototype.slice.call(arguments, 1);
-
-      for (var i = 0; i < args.length; i++) {
-        if (!obj || !obj.hasOwnProperty(args[i])) {
-          return false;
-        }
-        obj = obj[args[i]];
-      }
-      return true;
-    }
-
-    this.setActivity = function(activityName) {
-      currentActivity = activityName;
-    }
-
-    this.get = function(params) {
-      params = this._processParams(params);
-      return this._finish(agent.get(params.url).query(params.requestParams), params);
-    }
-
-    this.post = function(params) {
-      params = this._processParams(params);
-      return this._finish(agent.post(params.url).send(params.requestParams), params);
-    }
+  this.unauthorizedCallback = function() {
+    // noop
   };
-})();
+
+  this._handleResponses = function(params) {
+    var onError = params.onError;
+    var onSuccess = params.onSuccess;
+    var error = params.error;
+    var response = params.response;
+
+    // Slime in the ok and body.data properties
+    // for the ping api call.
+    if(response.text === '"OK"') {
+      response.ok = true;
+      response.body = {};
+      response.body.data = 'OK';
+    }
+
+    // Slime in the ok and body.data properties
+    // for the instance logs api call.
+    if(!response.body && typeof response.text === 'string' && !error) {
+      response.ok = true;
+      response.body = {};
+      response.body.data = response.text;
+    }
+
+    // Convert 0001-01-01T00:00:00Z to null
+    if(this._checkNested(response, 'body', 'data', 'components')) {
+      // If the response contains components,
+      // loop over them and check for and replace the null date
+
+      _.each(response.body.data.components, function(component){
+        _.each(component.instances, function(instance){
+          if(instance.create_date === '0001-01-01T00:00:00Z') {
+            instance.create_date = null;
+          }
+        });
+      });
+    }
+
+    if (response.ok) { onSuccess(response.body.data); return; }
+    if (response.unauthorized) { this.unauthorizedCallback(); }
+    if (error) { onError(error); return; }
+  };
+
+  this._validateOptionalCallback = function(callback, errorMessage) {
+    if (callback !== null && typeof callback !== 'function') { throw new UserException(errorMessage); }
+  };
+
+  this._validateRequiredCallback = function(callback, errorMessage) {
+    if (typeof callback !== 'function') { throw new UserException(errorMessage); }
+  };
+
+  this._processParams = function(params) {
+    params.headers = params.headers || {};
+    params.requestParams = params.requestParams;
+
+    if (currentActivity) {
+      params.headers[ACTIVITY_HEADER] = currentActivity;
+    }
+
+    params.headers[REQUEST_ID_HEADER] = requestID;
+
+    this._validateRequiredCallback(params.onSuccess, 'an onSuccess callback must be given and it must be a function');
+    this._validateOptionalCallback(params.onError, 'onError must be null or a function');
+
+    return params;
+  };
+
+  this._finish = function(_agent, params) {
+    return _agent.set(params.headers)
+      .end(function(error, response){
+        this._handleResponses({
+          error: error,
+          response: response,
+          onSuccess: params.onSuccess,
+          onError: params.onError
+        });
+      }.bind(this));
+  };
+
+  // Checks for the presence of a nested key
+  this._checkNested = function(obj /*, level1, level2, ... levelN*/) {
+    var args = Array.prototype.slice.call(arguments, 1);
+
+    for (var i = 0; i < args.length; i++) {
+      if (!obj || !obj.hasOwnProperty(args[i])) {
+        return false;
+      }
+      obj = obj[args[i]];
+    }
+    return true;
+  };
+
+  this.setActivity = function(activityName) {
+    currentActivity = activityName;
+  };
+
+  this.get = function(params) {
+    params = this._processParams(params);
+    return this._finish(agent.get(params.url).query(params.requestParams), params);
+  };
+
+  this.post = function(params) {
+    params = this._processParams(params);
+    return this._finish(agent.post(params.url).send(params.requestParams), params);
+  };
+};
 
 module.exports = RequestHelper;

--- a/lib/request_helper.js
+++ b/lib/request_helper.js
@@ -2,10 +2,12 @@ var agent = require('superagent');
 var _     = require('underscore');
 
 var ACTIVITY_HEADER = "X-Giant-Swarm-Activity";
+var REQUEST_ID_HEADER = "X-Giant-Swarm-Request-ID";
 
-var RequestHelper = (function() {
-  return function(){
+var RequestHelper = (function(requestID) {
+  return function(requestID){
     var currentActivity = null;
+    var requestID = requestID;
 
     this.unauthorizedCallback = function() {
       // noop
@@ -67,6 +69,8 @@ var RequestHelper = (function() {
       if (currentActivity) {
         params.headers[ACTIVITY_HEADER] = currentActivity;
       }
+
+      params.headers[REQUEST_ID_HEADER] = requestID;
 
       this._validateOptionalCallback(params.onError,   'onError must be null or a function');
       this._validateRequiredCallback(params.onSuccess, 'an onSuccess callback must be given');

--- a/lib/request_helper.js
+++ b/lib/request_helper.js
@@ -1,3 +1,4 @@
+var UserException = require('./user_exception.js')
 var agent = require('superagent');
 var _     = require('underscore');
 
@@ -55,11 +56,11 @@ var RequestHelper = (function(requestID) {
     }
 
     this._validateOptionalCallback = function(callback, errorMessage) {
-      if (callback !== null && typeof callback !== 'function') throw new this.UserException(errorMessage);
+      if (callback !== null && typeof callback !== 'function') throw new UserException(errorMessage);
     }
 
     this._validateRequiredCallback = function(callback, errorMessage) {
-      if (typeof callback !== 'function') throw new this.UserException(errorMessage);
+      if (typeof callback !== 'function') throw new UserException(errorMessage);
     }
 
     this._processParams = function(params) {
@@ -72,8 +73,9 @@ var RequestHelper = (function(requestID) {
 
       params.headers[REQUEST_ID_HEADER] = requestID;
 
+      this._validateRequiredCallback(params.onSuccess, 'an onSuccess callback must be given and it must be a function');
       this._validateOptionalCallback(params.onError,   'onError must be null or a function');
-      this._validateRequiredCallback(params.onSuccess, 'an onSuccess callback must be given');
+
       return params;
     }
 

--- a/lib/request_helper.js
+++ b/lib/request_helper.js
@@ -2,7 +2,7 @@ var agent = require('superagent');
 var _     = require('underscore');
 
 var ACTIVITY_HEADER = "X-Giant-Swarm-Activity";
-var REQUEST_ID_HEADER = "X-Giant-Swarm-Request-ID";
+var REQUEST_ID_HEADER = "X-Request-ID";
 
 var RequestHelper = (function(requestID) {
   return function(requestID){

--- a/lib/user_exception.js
+++ b/lib/user_exception.js
@@ -1,0 +1,11 @@
+// to be thrown in case of bad parameters/arguments/values given
+
+function UserException(message) {
+   Error.captureStackTrace(this);
+   this.message = message;
+   this.name = "UserException";
+}
+UserException.prototype = Object.create(Error.prototype);
+
+
+module.exports = UserException;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "js-base64": "^2.1.8",
     "js-data": "2.3.0",
+    "node-uuid": "^1.4.7",
     "superagent": "1.3.0",
     "superagent-mock": "git://github.com/oponder/superagent-mock#return-request",
     "underscore": "^1.8.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "js-base64": "^2.1.8",
     "js-data": "2.3.0",
     "superagent": "1.3.0",
-    "superagent-mock": "1.7.0",
+    "superagent-mock": "git://github.com/oponder/superagent-mock#return-request",
     "underscore": "^1.8.3",
     "ws": "0.7.2"
   },

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,1 +1,5 @@
-Copy `configuration.dist.js` to `configuration.js` and fill in missing values.
+Mock API Quirkyness:
+
+Anything api endpoint that matches pattern: 'https://api.*?io(.*)' will be a valid
+endpoint and continue to try to find matches for calls as created in the `mock_api/v1/`
+folder.

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -591,4 +591,35 @@ describe("giantSwarm", function() {
   });
 
 
+  // Request ID
+  //
+
+  it('sets a random request ID for each instantiation of the client', function() {
+    giantSwarm.setAuthToken("valid_token");
+    var request = giantSwarm.memberships(function(data){}, function(){});
+    firstRequestID = request.headers["X-Giant-Swarm-Request-ID"]
+
+    giantSwarm2 = new GiantSwarm();
+    giantSwarm2.setAuthToken("valid_token");
+    var request = giantSwarm2.memberships(function(data){}, function(){});
+    secondRequestID = request.headers["X-Giant-Swarm-Request-ID"]
+
+    expect(firstRequestID).not.toEqual(secondRequestID);
+  });
+
+  // Request ID
+  //
+
+  it('uses the same request ID for each request made with the same client', function() {
+    giantSwarm.setAuthToken("valid_token");
+    var request = giantSwarm.memberships(function(data){}, function(){});
+    firstRequestID = request.headers["X-Giant-Swarm-Request-ID"]
+
+    var response = giantSwarm.memberships(function(data){}, function(){});
+    secondRequestID = request.headers["X-Giant-Swarm-Request-ID"]
+
+    expect(firstRequestID).toEqual(secondRequestID);
+  });
+
+
 });

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -2,7 +2,7 @@ describe("GiantSwarm", function() {
 
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
-  var GiantSwarm = require('../lib/client');
+  var Client = require('../lib/client');
   var configuration = require('./configuration');
 
   var mocked_request = require('superagent');
@@ -11,6 +11,7 @@ describe("GiantSwarm", function() {
   require('superagent-mock')(mocked_request, config);
 
   beforeEach(function() {
+    GiantSwarm = new Client();
     GiantSwarm.setApiEndpoint('https://api.giantswarm.io');
     GiantSwarm.setAuthToken('valid_token');
     GiantSwarm.setClusterId(null);
@@ -553,5 +554,41 @@ describe("GiantSwarm", function() {
         fail(err);
         done();
       });
-  })
+  }),
+
+  // Activity Tracking
+
+  // // setActivity
+
+  it('sets the X-Giant-Swarm-Activity header', function() {
+    GiantSwarm.setAuthToken("valid_token");
+    GiantSwarm.setActivity("doing-a-cool-activity")
+
+    var response = GiantSwarm.memberships(function(data){}, function(){});
+
+    expect(response.headers["X-Giant-Swarm-Activity"]).toEqual("doing-a-cool-activity")
+  });
+
+  it('keeps the X-Giant-Swarm-Activity header for all subsequent requests', function() {
+    GiantSwarm.setAuthToken("valid_token");
+    GiantSwarm.setActivity("doing-something-that-takes-multiple-api-calls")
+
+    var response = GiantSwarm.memberships(function(data){}, function(){});
+
+    expect(response.headers["X-Giant-Swarm-Activity"]).toEqual("doing-something-that-takes-multiple-api-calls")
+
+    var response_2 = GiantSwarm.memberships(function(data){}, function(){});
+
+    expect(response.headers["X-Giant-Swarm-Activity"]).toEqual("doing-something-that-takes-multiple-api-calls")
+  });
+
+  it('does not set the X-Giant-Swarm-Activity header when not called', function() {
+    GiantSwarm.setAuthToken("valid_token");
+
+    var response = GiantSwarm.memberships(function(data){}, function(){});
+
+    expect(response.headers["X-Giant-Swarm-Activity"]).toEqual(undefined)
+  });
+
+
 });

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -22,14 +22,14 @@ describe("giantSwarm", function() {
   it("should throw an exception when given a non string url", function(done){
     expect(
       function(){ giantSwarm.setApiEndpoint(3) }
-    ).toThrow()
+    ).toThrowError("Parameter 'url' must be of type string")
     done();
   });
 
   it("should throw an exception when given no url", function(done){
     expect(
       function(){ giantSwarm.setApiEndpoint() }
-    ).toThrow()
+    ).toThrowError("Parameter 'url' must be given")
     done();
   });
 
@@ -84,14 +84,14 @@ describe("giantSwarm", function() {
     var func = function() {
       giantSwarm.ping();
     };
-    expect(func).toThrow();
+    expect(func).toThrowError('an onSuccess callback must be given and it must be a function');
   });
 
   it("should forbid to call ping with non-function parameter", function(){
     var func = function() {
       giantSwarm.ping("foo");
     };
-    expect(func).toThrow();
+    expect(func).toThrowError('an onSuccess callback must be given and it must be a function');
   });
 
   // // authenticate, user
@@ -597,12 +597,12 @@ describe("giantSwarm", function() {
   it('sets a random request ID for each instantiation of the client', function() {
     giantSwarm.setAuthToken("valid_token");
     var request = giantSwarm.memberships(function(data){}, function(){});
-    firstRequestID = request.headers["X-Giant-Swarm-Request-ID"]
+    firstRequestID = request.headers["X-Request-ID"]
 
     giantSwarm2 = new GiantSwarm();
     giantSwarm2.setAuthToken("valid_token");
     var request = giantSwarm2.memberships(function(data){}, function(){});
-    secondRequestID = request.headers["X-Giant-Swarm-Request-ID"]
+    secondRequestID = request.headers["X-Request-ID"]
 
     expect(firstRequestID).not.toEqual(secondRequestID);
   });
@@ -613,13 +613,11 @@ describe("giantSwarm", function() {
   it('uses the same request ID for each request made with the same client', function() {
     giantSwarm.setAuthToken("valid_token");
     var request = giantSwarm.memberships(function(data){}, function(){});
-    firstRequestID = request.headers["X-Giant-Swarm-Request-ID"]
+    firstRequestID = request.headers["X-Request-ID"]
 
     var response = giantSwarm.memberships(function(data){}, function(){});
-    secondRequestID = request.headers["X-Giant-Swarm-Request-ID"]
+    secondRequestID = request.headers["X-Request-ID"]
 
     expect(firstRequestID).toEqual(secondRequestID);
   });
-
-
 });

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -1,8 +1,8 @@
-describe("GiantSwarm", function() {
+describe("giantSwarm", function() {
 
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
-  var Client = require('../lib/client');
+  var GiantSwarm = require('../lib/client');
   var configuration = require('./configuration');
 
   var mocked_request = require('superagent');
@@ -11,44 +11,44 @@ describe("GiantSwarm", function() {
   require('superagent-mock')(mocked_request, config);
 
   beforeEach(function() {
-    GiantSwarm = new Client();
-    GiantSwarm.setApiEndpoint('https://api.giantswarm.io');
-    GiantSwarm.setAuthToken('valid_token');
-    GiantSwarm.setClusterId(null);
-    GiantSwarm.setUnauthorizedCallback(function() { null });
+    giantSwarm = new GiantSwarm();
+    giantSwarm.setApiEndpoint('https://api.giantswarm.io');
+    giantSwarm.setAuthToken('valid_token');
+    giantSwarm.setClusterId(null);
+    giantSwarm.setUnauthorizedCallback(function() { null });
   });
 
   // setApiEndpoint
   it("should throw an exception when given a non string url", function(done){
     expect(
-      function(){ GiantSwarm.setApiEndpoint(3) }
+      function(){ giantSwarm.setApiEndpoint(3) }
     ).toThrow()
     done();
   });
 
   it("should throw an exception when given no url", function(done){
     expect(
-      function(){ GiantSwarm.setApiEndpoint() }
+      function(){ giantSwarm.setApiEndpoint() }
     ).toThrow()
     done();
   });
 
   it("should set the websocketEndpoint correctly for http", function(done){
-    GiantSwarm.setApiEndpoint("http://api.example.com");
-    expect(GiantSwarm._getWebsocketEndpoint()).toEqual('ws://api.example.com');
+    giantSwarm.setApiEndpoint("http://api.example.com");
+    expect(giantSwarm._getWebsocketEndpoint()).toEqual('ws://api.example.com');
     done();
   });
 
   it("should set the websocketEndpoint correctly for https", function(done){
-    GiantSwarm.setApiEndpoint("https://api.example.com");
-    expect(GiantSwarm._getWebsocketEndpoint()).toEqual('wss://api.example.com');
+    giantSwarm.setApiEndpoint("https://api.example.com");
+    expect(giantSwarm._getWebsocketEndpoint()).toEqual('wss://api.example.com');
     done();
   });
 
   it("should fetch organizations which the current user is a member of", function(done){
-    GiantSwarm.setApiEndpoint("https://api.example.io");
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.memberships(function(data){
+    giantSwarm.setApiEndpoint("https://api.example.io");
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.memberships(function(data){
       expect(typeof(data)).toEqual('object');
       expect(data.length).toBeGreaterThan(0);
       expect(typeof(data[0])).toEqual('string');
@@ -62,7 +62,7 @@ describe("GiantSwarm", function() {
   // ping
 
   it("should allow me to ping the right server", function(done){
-    GiantSwarm.ping(function(){
+    giantSwarm.ping(function(){
       done();
     }, function(err){
       fail('ping() error callback called. This shouldn\'t have happened.' + err);
@@ -71,8 +71,8 @@ describe("GiantSwarm", function() {
   });
 
   it("should not allow me to ping google.com", function(done){
-    GiantSwarm.setApiEndpoint('https://www.google.com');
-    GiantSwarm.ping(function(){
+    giantSwarm.setApiEndpoint('https://www.google.com');
+    giantSwarm.ping(function(){
       fail('ping() success callback called. This shouldn\'t have happened.');
       done();
     }, function(err){
@@ -82,14 +82,14 @@ describe("GiantSwarm", function() {
 
   it("should forbid to call ping without callback", function(){
     var func = function() {
-      GiantSwarm.ping();
+      giantSwarm.ping();
     };
     expect(func).toThrow();
   });
 
   it("should forbid to call ping with non-function parameter", function(){
     var func = function() {
-      GiantSwarm.ping("foo");
+      giantSwarm.ping("foo");
     };
     expect(func).toThrow();
   });
@@ -97,10 +97,10 @@ describe("GiantSwarm", function() {
   // // authenticate, user
 
   it("should be able to authenticate a valid user", function(done){
-    GiantSwarm.authenticate(configuration.existingUser.username,
+    giantSwarm.authenticate(configuration.existingUser.username,
       configuration.existingUser.password,
       function(){
-        authToken = GiantSwarm.getAuthToken();
+        authToken = giantSwarm.getAuthToken();
         done();
       }, function(err){
         fail(err);
@@ -109,7 +109,7 @@ describe("GiantSwarm", function() {
   });
 
   it("should not be able to authenticate an invalid user", function(done){
-    GiantSwarm.authenticate(configuration.existingUser.username,
+    giantSwarm.authenticate(configuration.existingUser.username,
       'fooBarBlahFakePassword',
       function(){
         fail('an invalid user was able to authenticate');
@@ -120,8 +120,8 @@ describe("GiantSwarm", function() {
   });
 
   it("should be able to authenticate with a valid token", function(done){
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.user(function(data){
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.user(function(data){
       expect(data.username).toEqual(configuration.existingUser.username);
       done();
     }, function(err){
@@ -131,8 +131,8 @@ describe("GiantSwarm", function() {
   });
 
   it("should not be able to authenticate with an invalid token", function(done){
-    GiantSwarm.setAuthToken('invalid_token');
-    GiantSwarm.user(function(data){
+    giantSwarm.setAuthToken('invalid_token');
+    giantSwarm.user(function(data){
       fail('user() function called successCallback');
       done();
     }, function(err){
@@ -144,23 +144,23 @@ describe("GiantSwarm", function() {
   // // setClusterId
 
   it("should set the clusterId", function(done){
-    GiantSwarm.setClusterId('fakecluster.example.com');
-    expect(GiantSwarm._getClusterId()).toEqual("fakecluster.example.com");
+    giantSwarm.setClusterId('fakecluster.example.com');
+    expect(giantSwarm._getClusterId()).toEqual("fakecluster.example.com");
     done();
   });
 
   it("should throw an error on non string clusterIds", function(done){
-    expect(function(){GiantSwarm.setClusterId(3)}).toThrow();
-    expect(function(){GiantSwarm.setClusterId()}).toThrow();
+    expect(function(){giantSwarm.setClusterId(3)}).toThrow();
+    expect(function(){giantSwarm.setClusterId()}).toThrow();
     done();
   });
 
   // // setUnauthorizedCallback
 
   it("should set the callback and call it when a unauthorized call is made", function(done){
-    GiantSwarm.setAuthToken('invalid_token');
-    GiantSwarm.setUnauthorizedCallback(function() { done(); });
-    GiantSwarm.user(function() {
+    giantSwarm.setAuthToken('invalid_token');
+    giantSwarm.setUnauthorizedCallback(function() { done(); });
+    giantSwarm.user(function() {
       fail("Success callback called.")
       done();
     }, function() {
@@ -171,8 +171,8 @@ describe("GiantSwarm", function() {
   // // // memberships
 
   it("should fetch organizations which the current user is a member of", function(done){
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.memberships(function(data){
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.memberships(function(data){
       expect(typeof(data)).toEqual('object');
       expect(data.length).toBeGreaterThan(0);
       expect(typeof(data[0])).toEqual('string');
@@ -186,8 +186,8 @@ describe("GiantSwarm", function() {
   // // // organization
 
   it("should fetch organization details", function(done){
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.organization(configuration.organizationName,
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.organization(configuration.organizationName,
       function(data){
         expect(typeof(data)).toEqual('object');
         expect(typeof(data.id)).toEqual('string');
@@ -202,8 +202,8 @@ describe("GiantSwarm", function() {
   // // // environments
 
   it("should fetch environments within an organization", function(done){
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.environments(configuration.organizationName,
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.environments(configuration.organizationName,
       function(data){
         expect(typeof(data)).toEqual('object');
         done();
@@ -216,8 +216,8 @@ describe("GiantSwarm", function() {
   // // // services
 
   it("should fetch services within an environment", function(done){
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.services(configuration.organizationName,
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.services(configuration.organizationName,
       configuration.environmentName,
       function(data){
         expect(typeof(data)).toEqual('object');
@@ -231,7 +231,7 @@ describe("GiantSwarm", function() {
   // // // serviceStatus
 
   it("should fetch the status of a service", function(done){
-    GiantSwarm.serviceStatus(configuration.organizationName,
+    giantSwarm.serviceStatus(configuration.organizationName,
       configuration.environmentName,
       configuration.serviceName,
       function(data){
@@ -252,7 +252,7 @@ describe("GiantSwarm", function() {
   // // // service definition
 
   it("should fetch the definition of a service", function(done){
-    GiantSwarm.serviceDefinition(configuration.organizationName,
+    giantSwarm.serviceDefinition(configuration.organizationName,
       configuration.environmentName,
       configuration.serviceName,
       function(data){
@@ -267,7 +267,7 @@ describe("GiantSwarm", function() {
   // // // service stop
 
   it("should stop a service", function(done){
-   GiantSwarm.stopService(configuration.organizationName,
+   giantSwarm.stopService(configuration.organizationName,
      configuration.environmentName,
      configuration.serviceName,
      function(data){
@@ -282,7 +282,7 @@ describe("GiantSwarm", function() {
   // // // service start
 
   it("should start a service", function(done){
-    GiantSwarm.startService(configuration.organizationName,
+    giantSwarm.startService(configuration.organizationName,
       configuration.environmentName,
       configuration.serviceName,
       function(data){
@@ -297,7 +297,7 @@ describe("GiantSwarm", function() {
   // // // componentStatus
 
   it("should fetch the status of a known component", function(done){
-    GiantSwarm.componentStatus(
+    giantSwarm.componentStatus(
       configuration.organizationName,
       configuration.environmentName,
       configuration.serviceName,
@@ -314,7 +314,7 @@ describe("GiantSwarm", function() {
   });
 
   it("calls the error callback on unknown component", function(done){
-    GiantSwarm.componentStatus(
+    giantSwarm.componentStatus(
       configuration.organizationName,
       configuration.environmentName,
       configuration.serviceName,
@@ -330,7 +330,7 @@ describe("GiantSwarm", function() {
   // // startComponent
 
   it("starts a known component", function(done){
-    GiantSwarm.startComponent(
+    giantSwarm.startComponent(
       configuration.organizationName,
       configuration.environmentName,
       configuration.serviceName,
@@ -344,7 +344,7 @@ describe("GiantSwarm", function() {
   });
 
   it("calls the error callback for an unknown component", function(done){
-    GiantSwarm.startComponent(
+    giantSwarm.startComponent(
       configuration.organizationName,
       configuration.environmentName,
       configuration.serviceName,
@@ -360,7 +360,7 @@ describe("GiantSwarm", function() {
   // // stopComponent
 
   it("stops a known component", function(done){
-    GiantSwarm.stopComponent(
+    giantSwarm.stopComponent(
       configuration.organizationName,
       configuration.environmentName,
       configuration.serviceName,
@@ -374,7 +374,7 @@ describe("GiantSwarm", function() {
   });
 
   it("calls error callback for unknown component", function(done){
-    GiantSwarm.stopComponent(
+    giantSwarm.stopComponent(
       configuration.organizationName,
       configuration.environmentName,
       configuration.serviceName,
@@ -391,7 +391,7 @@ describe("GiantSwarm", function() {
   // // instanceStats
 
   it("should fetch the stats of an instance", function(done){
-    GiantSwarm.instanceStats(configuration.organizationName,
+    giantSwarm.instanceStats(configuration.organizationName,
       configuration.instanceId,
       function(data){
         expect(typeof(data)).toEqual('object');
@@ -410,7 +410,7 @@ describe("GiantSwarm", function() {
   // // instanceLogs
 
   it("responds with 10 lines by default", function(done){
-    GiantSwarm.instanceLogs(configuration.organizationName,
+    giantSwarm.instanceLogs(configuration.organizationName,
       configuration.instanceId,
       null,
       function(data){
@@ -423,7 +423,7 @@ describe("GiantSwarm", function() {
   });
 
   it("works when there are no log lines returned", function(done) {
-    GiantSwarm.instanceLogs(configuration.organizationName,
+    giantSwarm.instanceLogs(configuration.organizationName,
       "instanceWithNoLogs",
       null,
       function(data){
@@ -435,7 +435,7 @@ describe("GiantSwarm", function() {
   })
 
   it("responds with 2 lines when asked", function(done){
-    GiantSwarm.instanceLogs(configuration.organizationName,
+    giantSwarm.instanceLogs(configuration.organizationName,
       configuration.instanceId,
       1,
       function(data){
@@ -449,7 +449,7 @@ describe("GiantSwarm", function() {
   });
 
   it("calls error callback for unknown instance", function(done){
-    GiantSwarm.instanceLogs(configuration.organizationName,
+    giantSwarm.instanceLogs(configuration.organizationName,
       "invalid_instance",
       1,
       function(data){
@@ -463,7 +463,7 @@ describe("GiantSwarm", function() {
   // streamLogs
 
   it("returns a websocket with a sensible url to stream logs, calls the message callback onmessage", function(done){
-    GiantSwarm.streamLogs(configuration.organizationName,
+    giantSwarm.streamLogs(configuration.organizationName,
       [configuration.instanceId],
       function(message){done();},
       function(socket){
@@ -479,7 +479,7 @@ describe("GiantSwarm", function() {
   // streamStats
 
   it("returns a websocket with a sensible url to stream stats, calls the message callback onmessage", function(done){
-    GiantSwarm.streamStats(configuration.organizationName,
+    giantSwarm.streamStats(configuration.organizationName,
       [configuration.instanceId],
       2,
       function(message){done();},
@@ -496,8 +496,8 @@ describe("GiantSwarm", function() {
   // // logout
 
   it("logs out a logged in user", function(done){
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.logout(
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.logout(
       function(data){
         done()
       },
@@ -508,9 +508,9 @@ describe("GiantSwarm", function() {
   });
 
   it("calls error callback for non logged in user", function(done){
-    GiantSwarm.setAuthToken("invalid_token");
+    giantSwarm.setAuthToken("invalid_token");
 
-    GiantSwarm.logout(
+    giantSwarm.logout(
       function(data){
         fail("success callback was called for invalid token ")
         done()
@@ -523,8 +523,8 @@ describe("GiantSwarm", function() {
   // // isAuthenticated
 
   it("returns true when user is logged in", function(done){
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.isAuthenticated(
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.isAuthenticated(
       function(response){
         expect(response).toEqual(true);
         done();
@@ -532,8 +532,8 @@ describe("GiantSwarm", function() {
   });
 
   it("returns false when user is logged out", function(done){
-    GiantSwarm.setAuthToken("not_logged_in_user");
-    GiantSwarm.isAuthenticated(
+    giantSwarm.setAuthToken("not_logged_in_user");
+    giantSwarm.isAuthenticated(
       function(response){
         expect(response).toEqual(false);
         done();
@@ -543,8 +543,8 @@ describe("GiantSwarm", function() {
   // Null Dates
 
   it("converts 0001-01-01T00:00:00Z to null for dates", function(done) {
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.serviceStatus(configuration.organizationName,
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.serviceStatus(configuration.organizationName,
       configuration.environmentName,
       "deleting_service",
       function(data){
@@ -561,31 +561,31 @@ describe("GiantSwarm", function() {
   // // setActivity
 
   it('sets the X-Giant-Swarm-Activity header', function() {
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.setActivity("doing-a-cool-activity")
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.setActivity("doing-a-cool-activity")
 
-    var response = GiantSwarm.memberships(function(data){}, function(){});
+    var response = giantSwarm.memberships(function(data){}, function(){});
 
     expect(response.headers["X-Giant-Swarm-Activity"]).toEqual("doing-a-cool-activity")
   });
 
   it('keeps the X-Giant-Swarm-Activity header for all subsequent requests', function() {
-    GiantSwarm.setAuthToken("valid_token");
-    GiantSwarm.setActivity("doing-something-that-takes-multiple-api-calls")
+    giantSwarm.setAuthToken("valid_token");
+    giantSwarm.setActivity("doing-something-that-takes-multiple-api-calls")
 
-    var response = GiantSwarm.memberships(function(data){}, function(){});
+    var response = giantSwarm.memberships(function(data){}, function(){});
 
     expect(response.headers["X-Giant-Swarm-Activity"]).toEqual("doing-something-that-takes-multiple-api-calls")
 
-    var response_2 = GiantSwarm.memberships(function(data){}, function(){});
+    var response_2 = giantSwarm.memberships(function(data){}, function(){});
 
     expect(response.headers["X-Giant-Swarm-Activity"]).toEqual("doing-something-that-takes-multiple-api-calls")
   });
 
   it('does not set the X-Giant-Swarm-Activity header when not called', function() {
-    GiantSwarm.setAuthToken("valid_token");
+    giantSwarm.setAuthToken("valid_token");
 
-    var response = GiantSwarm.memberships(function(data){}, function(){});
+    var response = giantSwarm.memberships(function(data){}, function(){});
 
     expect(response.headers["X-Giant-Swarm-Activity"]).toEqual(undefined)
   });

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -22,14 +22,14 @@ describe("giantSwarm", function() {
   it("should throw an exception when given a non string url", function(done){
     expect(
       function(){ giantSwarm.setApiEndpoint(3) }
-    ).toThrowError("Parameter 'url' must be of type string")
+    ).toThrowError('Parameter "url" must be of type string')
     done();
   });
 
   it("should throw an exception when given no url", function(done){
     expect(
       function(){ giantSwarm.setApiEndpoint() }
-    ).toThrowError("Parameter 'url' must be given")
+    ).toThrowError('Parameter "url" must be given')
     done();
   });
 


### PR DESCRIPTION
Related to: https://github.com/giantswarm/webclient/issues/189

This PR adds:

* optional method `setActivity()` to set the activity that should be sent in the `X-Giant-Swarm-Activity` header for all requests after that point.
* always present Header `X-Request-ID` with a random ID sent with every request

Furthermore:
`GiantSwarm` and `RequestHelper` are now Object Constructors instead of a singleton. 

This will require some small changes in `webclient`, but means we can create individual instances of the client, and be assured that we're not accidentally still using a request ID or an activityName from a previous call.

i.e. before
```
var GiantSwarm = require('../lib/client');
GiantSwarm.setApiEndpoint('https://api.giantswarm.io');
GiantSwarm.ping(...);
```

after
```
var GiantSwarm = require('../lib/client');
var giantSwarm = new GiantSwarm();
giantSwarm.setApiEndpoint('https://api.giantswarm.io');

giantSwarm.setActivity('pinging');  // not a real activity name, just for example

giantSwarm.ping(...);  // Requests made will now have 
                       // X-Request-ID and X-Giant-Swarm-Activity set
```

Opens doors for more refactoring, but will not go down that road for now