### PR TITLE
Add cluster_details and clusters v3 API calls

### DIFF
--- a/lib/api_calls/cluster_details.js
+++ b/lib/api_calls/cluster_details.js
@@ -1,0 +1,14 @@
+var stampit = require('stampit');
+
+module.exports = stampit().
+  methods({
+    clusterDetails: function(params) {
+      return this.getRequest(this.apiEndpoint + "/v3/clusters/" + params.clusterId + "/").
+      then(function(response) {
+        return {
+          result: response.body.data,
+          rawResponse: response
+        }
+      });
+    }
+  });

--- a/lib/api_calls/clusters.js
+++ b/lib/api_calls/clusters.js
@@ -1,0 +1,14 @@
+var stampit = require('stampit');
+
+module.exports = stampit().
+  methods({
+    clusters: function(params) {
+      return this.getRequest(this.apiEndpoint + "/v3/orgs/" + params.organizationName+ "/clusters/").
+      then(function(response) {
+        return {
+          result: response.body.data,
+          rawResponse: response
+        }
+      });
+    }
+  });

--- a/lib/client.js
+++ b/lib/client.js
@@ -26,7 +26,9 @@ var apiCalls = [
   require('./api_calls/stream_logs.js'),
   require('./api_calls/stream_stats.js'),
   require('./api_calls/wait_for.js'),
-  require('./api_calls/user.js')
+  require('./api_calls/user.js'),
+  require('./api_calls/cluster_details.js'),
+  require('./api_calls/clusters.js')
 ];
 
 validate.validators.isStringOrUndefined = function(value) {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -747,4 +747,85 @@ describe("giantSwarm", function() {
       });
     });
   });
+
+  describe("#clusterDetails", function() {
+    describe("for an existing cluster", function() {
+      it("returns details about a valid cluster", function(done){
+        this.giantSwarm = GiantSwarm(testConfiguration);
+        this.request = this.giantSwarm.clusterDetails({
+          clusterId: 'valid_cluster_id'
+        });
+
+        this.request.then(function(response) {
+          expect(response.result.api_endpoint).toEqual("https://valid_cluster_id.giantswarm-kaas.io");
+          done();
+        });
+      });
+    });
+
+    describe("for a non existing cluster", function() {
+      it("rejects the promise", function(done){
+        this.giantSwarm = GiantSwarm(testConfiguration);
+        this.request = this.giantSwarm.clusterDetails({
+          clusterId: 'non_existing_cluster'
+        });
+
+        this.request.then(function(response) {
+          fail("Should not have reached this success branch")
+        })
+        .catch(function(error) {
+          expect(error.status).toEqual(400);
+          expect(error.res.body.status_code).toEqual(10008);
+          done();
+        });
+      });
+    });
+
+    describe("for exceptional situations", function() {
+      it("it rejects the promise", function(done){
+        this.giantSwarm = GiantSwarm(testConfiguration);
+        this.request = this.giantSwarm.clusterDetails({
+          clusterId: 'cluster_id_that_will_500'
+        });
+
+        this.request.then(function(response) {
+          fail("Should not have reached this success branch")
+        })
+        .catch(function(error) {
+          expect(error.status).toEqual(500);
+          done();
+        });
+      });
+    });
+  });
+
+  describe("#clusters", function() {
+    describe("for an existing organization with clusters", function() {
+      it("returns a list of clusters", function(done){
+        this.giantSwarm = GiantSwarm(testConfiguration);
+        this.request = this.giantSwarm.clusters({
+          organizationName: 'validorg'
+        });
+
+        this.request.then(function(response) {
+          expect(response.result.clusters.length).toEqual(2);
+          done();
+        });
+      });
+    });
+
+    describe("for an existing organization without any clusters", function() {
+      it("returns an empty list of clusters", function(done){
+        this.giantSwarm = GiantSwarm(testConfiguration);
+        this.request = this.giantSwarm.clusters({
+          organizationName: 'some_other_org'
+        });
+
+        this.request.then(function(response) {
+          expect(response.result.clusters.length).toEqual(0);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
rfr @marians

This adds calls to get details about a cluster and the list of clusters belonging to an organization.
The cluster ownership POST call is an admin feature and so didn't include it in this client.