### PR TITLE
Add create and list key-pairs methods

### DIFF
--- a/lib/api_calls/key_pairs.js
+++ b/lib/api_calls/key_pairs.js
@@ -1,0 +1,17 @@
+var stampit = require('stampit');
+
+module.exports = stampit().
+  methods({
+    createClusterKeyPair: function(params) {
+      return this.postRequest(this.apiEndpoint + "/v3/clusters/" + params.clusterId + "/key-pair/",
+      {
+        description: params.description
+      })
+      .then(function(response) {
+        return {
+          result: response.body.data,
+          rawResponse: response
+        }
+      });
+    }
+  });

--- a/lib/api_calls/key_pairs.js
+++ b/lib/api_calls/key_pairs.js
@@ -2,10 +2,21 @@ var stampit = require('stampit');
 
 module.exports = stampit().
   methods({
+    clusterKeyPairs: function(params) {
+      return this.getRequest(this.apiEndpoint + "/v3/clusters/" + params.clusterId + "/key-pairs/")
+      .then(function(response) {
+        return {
+          result: response.body.data,
+          rawResponse: response
+        }
+      });
+    },
+
     createClusterKeyPair: function(params) {
-      return this.postRequest(this.apiEndpoint + "/v3/clusters/" + params.clusterId + "/key-pair/",
+      return this.postRequest(this.apiEndpoint + "/v3/clusters/" + params.clusterId + "/key-pairs/",
       {
-        description: params.description
+        description: params.description,
+        ttl_hours: params.ttl_hours
       })
       .then(function(response) {
         return {

--- a/lib/client.js
+++ b/lib/client.js
@@ -29,7 +29,8 @@ var apiCalls = [
   require('./api_calls/wait_for.js'),
   require('./api_calls/user.js'),
   require('./api_calls/cluster_details.js'),
-  require('./api_calls/clusters.js')
+  require('./api_calls/clusters.js'),
+  require('./api_calls/key_pairs.js')
 ];
 
 validate.validators.isStringOrUndefined = function(value) {

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -915,7 +915,7 @@ describe("giantSwarm", function() {
       it("returns details about the created key-pair", function(done){
 
         this.giantSwarm = GiantSwarm(testConfiguration);
-        this.request = this.giantSwarm.clusterDetails({
+        this.request = this.giantSwarm.createClusterKeyPair({
           clusterId: 'valid_cluster_id',
           description: 'my personal description for this key-pair'
         });
@@ -923,6 +923,9 @@ describe("giantSwarm", function() {
         this.request.then(function(response) {
           expect(response.result.description).toEqual("my personal description for this key-pair");
           done();
+        })
+        .catch(function(error) {
+          fail(error);
         });
 
       });

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -910,6 +910,66 @@ describe("giantSwarm", function() {
     });
   });
 
+  describe("#createClusterKeyPair", function() {
+    describe("for an existing cluster", function() {
+      it("returns details about the created key-pair", function(done){
+
+        this.giantSwarm = GiantSwarm(testConfiguration);
+        this.request = this.giantSwarm.clusterDetails({
+          clusterId: 'valid_cluster_id',
+          description: 'my personal description for this key-pair'
+        });
+
+        this.request.then(function(response) {
+          expect(response.result.description).toEqual("my personal description for this key-pair");
+          done();
+        });
+
+      });
+    });
+
+    describe("for a non existing cluster", function() {
+      it("rejects the promise", function(done){
+
+        this.giantSwarm = GiantSwarm(testConfiguration);
+        this.request = this.giantSwarm.createClusterKeyPair({
+          clusterId: 'non_existing_cluster',
+          description: 'some description'
+        });
+
+        this.request.then(function(response) {
+          fail("Should not have reached this success branch")
+        })
+        .catch(function(error) {
+          expect(error.status).toEqual(400);
+          expect(error.res.body.status_code).toEqual(10008);
+          done();
+        });
+
+      });
+    });
+
+    describe("for exceptional situations", function() {
+      it("it rejects the promise", function(done){
+
+        this.giantSwarm = GiantSwarm(testConfiguration);
+        this.request = this.giantSwarm.createClusterKeyPair({
+          clusterId: 'cluster_id_that_will_500',
+          description: 'some description'
+        });
+
+        this.request.then(function(response) {
+          fail("Should not have reached this success branch")
+        })
+        .catch(function(error) {
+          expect(error.status).toEqual(500);
+          done();
+        });
+
+      });
+    });
+  });
+
   describe("#clusters", function() {
     describe("for an existing organization with clusters", function() {
       it("returns a list of clusters", function(done){

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -910,6 +910,55 @@ describe("giantSwarm", function() {
     });
   });
 
+  describe("#clusterKeyPairs", function() {
+    describe("for an existing cluster, with no key-pairs yet", function() {
+      it("returns an empty array", function(done) {
+
+        this.giantSwarm = GiantSwarm(testConfiguration);
+        this.request = this.giantSwarm.clusterKeyPairs({
+          clusterId: 'valid_cluster_id'
+        });
+
+        this.request.then(function(response) {
+          expect(response.result.key_pairs).toEqual([]);
+          done();
+        })
+        .catch(function(error) {
+          fail(error);
+        });
+      });
+    });
+
+    describe("for an existing cluster, after creating a key-pair", function() {
+      it("returns that key pair", function(done) {
+
+        this.giantSwarm = GiantSwarm(testConfiguration);
+
+        this.request = this.giantSwarm.createClusterKeyPair({
+          clusterId: 'valid_cluster_id',
+          description: 'just testing :D',
+          ttl_hours: 200
+        })
+        .then(function() {
+          return this.giantSwarm.clusterKeyPairs({
+            clusterId: 'valid_cluster_id'
+          });
+        })
+        .then(function(response) {
+          expect(response.result.key_pairs.length).toEqual(1);
+          console.log(response.result.key_pairs);
+          expect(response.result.key_pairs[0].description).toEqual("just testing :D");
+          expect(response.result.key_pairs[0].ttl_hours).toEqual(200);
+          done();
+        })
+        .catch(function(error) {
+          fail(error);
+        });
+
+      });
+    });
+  });
+
   describe("#createClusterKeyPair", function() {
     describe("for an existing cluster", function() {
       it("returns details about the created key-pair", function(done){


### PR DESCRIPTION
This adds a method called `clusterKeyPairs` and `createClusterKeyPair` which correspond with the `GET` and `POST` `/v3/clusters/:clusterId/key-pairs/` end points of our API.

The endpoint was first introduced and discussed here: https://github.com/giantswarm/mock-api/pull/24