### PR TITLE
Use correct key for KeyPair response

### DIFF
--- a/lib/api_calls/key_pairs.js
+++ b/lib/api_calls/key_pairs.js
@@ -6,7 +6,7 @@ module.exports = stampit().
       return this.getRequest(this.apiEndpoint + "/v3/clusters/" + params.clusterId + "/key-pairs/")
       .then(function(response) {
         return {
-          result: response.body.data,
+          result: response.body.data.KeyPairs,
           rawResponse: response
         }
       });

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -940,7 +940,7 @@ describe("giantSwarm", function() {
         });
 
         this.request.then(function(response) {
-          expect(response.result.key_pairs).toEqual([]);
+          expect(response.result).toEqual([]);
           done();
         })
         .catch(function(error) {
@@ -965,9 +965,9 @@ describe("giantSwarm", function() {
           });
         })
         .then(function(response) {
-          expect(response.result.key_pairs.length).toEqual(1);
-          expect(response.result.key_pairs[0].description).toEqual("just testing :D");
-          expect(response.result.key_pairs[0].ttl_hours).toEqual(200);
+          expect(response.result.length).toEqual(1);
+          expect(response.result[0].description).toEqual("just testing :D");
+          expect(response.result[0].ttl_hours).toEqual(200);
           done();
         })
         .catch(function(error) {


### PR DESCRIPTION
It makes it so consumers of this client do not have to care what the right key is to get to the array of key pairs. 

This is in line with other calls that return an array of objects.

The reason this PR is being made is because currently the API returns the key pairs in a key called `KeyPairs`. 
The casing is not in line with the rest of the API. However the js-client should shield implementors from this discrepancy.