### PR TITLE
Use email related org routes

### DIFF
--- a/lib/api_calls/organization.js
+++ b/lib/api_calls/organization.js
@@ -3,7 +3,7 @@ var stampit = require('stampit');
 module.exports = stampit().
   methods({
     organization: function(params) {
-      return this.getRequest(this.apiEndpoint + "/v1/org/" + params.organizationName)
+      return this.getRequest(this.apiEndpoint + "/v2/org/" + params.organizationName)
       .then(function(response) {
         return {
           result: response.body.data,
@@ -38,7 +38,7 @@ module.exports = stampit().
     addMemberToOrganization: function(params) {
       return this.postRequest(this.apiEndpoint + "/v1/org/" + params.organizationName + "/members/add",
       {
-        username: params.username
+        email: params.email
       })
       .then(function(response) {
         return {
@@ -51,7 +51,7 @@ module.exports = stampit().
     removeMemberFromOrganization: function(params) {
       return this.postRequest(this.apiEndpoint + "/v1/org/" + params.organizationName + "/members/remove",
       {
-        username: params.username
+        email: params.email
       })
       .then(function(response) {
         return {


### PR DESCRIPTION
This makes the js client use the newer email related org routes.

Related to: https://github.com/giantswarm/giantswarm/issues/985