### PR TITLE
Use new /v4/clusters/ endpoint

### DIFF
--- a/lib/api_calls/clusters.js
+++ b/lib/api_calls/clusters.js
@@ -3,7 +3,7 @@ var stampit = require('stampit');
 module.exports = stampit().
   methods({
     clusters: function(params) {
-      return this.getRequest(this.apiEndpoint + "/v4/orgs/" + params.organizationName+ "/clusters/").
+      return this.getRequest(this.apiEndpoint + "/v4/clusters/").
       then(function(response) {
         return {
           result: response.body,


### PR DESCRIPTION
Makes the cluster listing no longer use the "/v4/orgs/" + params.organizationName+ "/clusters/" endpoint, and instead
the /v4/clusters/ endpoint. Implementors should do the filtering for orgs on their own if they need to from now on.

Happa will get a corresponding update.