### PR TITLE
/v4/ add/remove members from organizations

### DIFF
--- a/lib/api_calls/organization.js
+++ b/lib/api_calls/organization.js
@@ -1,12 +1,13 @@
 var stampit = require('stampit');
+var _ = require('underscore');
 
 module.exports = stampit().
   methods({
     organization: function(params) {
-      return this.getRequest(this.apiEndpoint + "/v2/org/" + params.organizationName)
+      return this.getRequest(this.apiEndpoint + "/v4/organizations/" + params.organizationName + "/")
       .then(function(response) {
         return {
-          result: response.body.data,
+          result: response.body,
           rawResponse: response
         }
       });
@@ -33,10 +34,22 @@ module.exports = stampit().
     },
 
     addMemberToOrganization: function(params) {
-      return this.postRequest(this.apiEndpoint + "/v1/org/" + params.organizationName + "/members/add",
-      {
-        email: params.email
+      var members;
+
+      return this.getRequest(this.apiEndpoint + "/v4/organizations/" + params.organizationName + "/")
+      .then(function(response) {
+        response.body.members.push({email: params.email});
+        members = _.uniq(response.body.members, false, (member) => {
+          return member.email
+        });
+        return members;
       })
+      .then((members => {
+        return this.patchRequest(this.apiEndpoint + "/v4/organizations/" + params.organizationName + "/",
+        {
+          members: members
+        })
+      }))
       .then(function(response) {
         return {
           result: response.body,
@@ -46,10 +59,22 @@ module.exports = stampit().
     },
 
     removeMemberFromOrganization: function(params) {
-      return this.postRequest(this.apiEndpoint + "/v1/org/" + params.organizationName + "/members/remove",
-      {
-        email: params.email
+      var members;
+
+      return this.getRequest(this.apiEndpoint + "/v4/organizations/" + params.organizationName + "/")
+      .then(function(response) {
+        members = _.reject(response.body.members, (member) => {
+          return member.email === params.email;
+        });
+
+        return members;
       })
+      .then((members => {
+        return this.patchRequest(this.apiEndpoint + "/v4/organizations/" + params.organizationName + "/",
+        {
+          members: members
+        })
+      }))
       .then(function(response) {
         return {
           result: response.body,

--- a/lib/api_calls/organization.js
+++ b/lib/api_calls/organization.js
@@ -39,17 +39,17 @@ module.exports = stampit().
       return this.getRequest(this.apiEndpoint + "/v4/organizations/" + params.organizationName + "/")
       .then(function(response) {
         response.body.members.push({email: params.email});
-        members = _.uniq(response.body.members, false, (member) => {
-          return member.email
+        members = _.uniq(response.body.members, false, function(member) {
+          return member.email;
         });
         return members;
       })
-      .then((members => {
+      .then((function(members) {
         return this.patchRequest(this.apiEndpoint + "/v4/organizations/" + params.organizationName + "/",
         {
           members: members
         })
-      }))
+      }).bind(this))
       .then(function(response) {
         return {
           result: response.body,
@@ -63,18 +63,18 @@ module.exports = stampit().
 
       return this.getRequest(this.apiEndpoint + "/v4/organizations/" + params.organizationName + "/")
       .then(function(response) {
-        members = _.reject(response.body.members, (member) => {
+        members = _.reject(response.body.members, function(member) {
           return member.email === params.email;
         });
 
         return members;
       })
-      .then((members => {
+      .then((function(members) {
         return this.patchRequest(this.apiEndpoint + "/v4/organizations/" + params.organizationName + "/",
         {
           members: members
         })
-      }))
+      }).bind(this))
       .then(function(response) {
         return {
           result: response.body,

--- a/lib/request_helper.js
+++ b/lib/request_helper.js
@@ -75,6 +75,14 @@ var requestHelper = stampit().
       return r;
     },
 
+    patchRequest: function(url, params){
+      var r = request.patch(url).
+      send(params).
+      set(this.headers()).then(fixDates);
+      r.catch(this.handleUnauthorized.bind(this));
+      return r;
+    },
+
     deleteRequest: function(url, params){
       var r = request.delete(url).
       send(params).


### PR DESCRIPTION
Uses the new `PATCH /v4/organizations/:org-id/` endpoint to add and remove members. It will now first fetch the list of users, modify the array, and then send the patch.