### PR TITLE
Add listing organizations via /v4/organizations/

### DIFF
--- a/lib/api_calls/organization.js
+++ b/lib/api_calls/organization.js
@@ -3,6 +3,16 @@ var _ = require('underscore');
 
 module.exports = stampit().
   methods({
+    organizations: function(params) {
+      return this.getRequest(this.apiEndpoint + "/v4/organizations/")
+      .then(function(response) {
+        return {
+          result: response.body,
+          rawResponse: response
+        }
+      });
+    },
+
     organization: function(params) {
       return this.getRequest(this.apiEndpoint + "/v4/organizations/" + params.organizationName + "/")
       .then(function(response) {


### PR DESCRIPTION
This adds a way to get your organizations via the /v4/ endpoint.

The /v4/ endpoint is better because it respects admin rights and lists all orgs if the call is performed by an admin.

This lets us get to a place where Happa lists all orgs for anyone that is part of the admin organization (https://github.com/giantswarm/api/issues/423)