### PR TITLE
Use v4 version of keypair endpoints

### DIFF
--- a/lib/api_calls/key_pairs.js
+++ b/lib/api_calls/key_pairs.js
@@ -3,24 +3,24 @@ var stampit = require('stampit');
 module.exports = stampit().
   methods({
     clusterKeyPairs: function(params) {
-      return this.getRequest(this.apiEndpoint + "/v3/clusters/" + params.clusterId + "/key-pairs/")
+      return this.getRequest(this.apiEndpoint + "/v4/clusters/" + params.clusterId + "/key-pairs/")
       .then(function(response) {
         return {
-          result: response.body.data.KeyPairs,
+          result: response.body,
           rawResponse: response
         }
       });
     },
 
     createClusterKeyPair: function(params) {
-      return this.postRequest(this.apiEndpoint + "/v3/clusters/" + params.clusterId + "/key-pairs/",
+      return this.postRequest(this.apiEndpoint + "/v4/clusters/" + params.clusterId + "/key-pairs/",
       {
         description: params.description,
         ttl_hours: params.ttl_hours
       })
       .then(function(response) {
         return {
-          result: response.body.data,
+          result: response.body,
           rawResponse: response
         }
       });


### PR DESCRIPTION
Goes towards https://github.com/giantswarm/giantswarm/issues/1524 (stop using deprecated api routes in our own clients)