### PR TITLE
Add cn_prefix and certificate_organizations params

### DIFF
--- a/lib/api_calls/key_pairs.js
+++ b/lib/api_calls/key_pairs.js
@@ -16,7 +16,9 @@ module.exports = stampit().
       return this.postRequest(this.apiEndpoint + "/v4/clusters/" + params.clusterId + "/key-pairs/",
       {
         description: params.description,
-        ttl_hours: params.ttl_hours
+        ttl_hours: params.ttl_hours,
+        cn_prefix: params.cn_prefix,
+        certificate_organizations: params.certificate_organizations
       })
       .then(function(response) {
         return {


### PR DESCRIPTION
So that Happa can make use of the new functionality to request keypairs with custom common_name prefixes and "O"s