### PR TITLE
Update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,5 +27,5 @@ jobs:
       - run:
           name: Check for dependency updates
           command: |
-            sudo npm install -g --no-progress npm-check-updates
+            npm install -g --no-progress npm-check-updates
             ncu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: ~/giantswarm-js-client
-    docker:
-      - image: circleci/node:6-stretch
+    machine: true
     steps:
       - checkout
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,4 @@
 {
-  "ecmaFeatures": {
-    "jsx": true,
-    "modules": true,
-    "classes": true
-  },
   "env": {
     "browser": true,
     "node": true,

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 dist/
 node_modules/
-spec/configuration.js
 npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends git build-es
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# RUN npm install utf-8-validate@1.1.0
-# RUN npm install bufferutil@1.1.0
 RUN npm install -g node-gyp
 
 # Install app dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.2.2-slim
+FROM node:6-slim
 RUN apt-get update -y && apt-get install -y --no-install-recommends git build-essential python && rm -rf /var/cache/apk/*
 
 # Create app directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "2"
 services:
+
   jsclient:
     build: ./
     image: giantswarm-js-client-tests
     command: npm test
-    links:
-      - "mockapi:mockapi"
+
   mockapi:
-    image: registry.giantswarm.io/giantswarm/mock-api:latest
+    image: quay.io/giantswarm/mock-api:latest
     ports:
       - "8000:8000"
     environment:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ var source = require('vinyl-source-stream');
 var buffer = require('vinyl-buffer');
 var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var eslint = require('gulp-eslint');
 
 gulp.task('eslint', function() {
@@ -29,7 +29,7 @@ gulp.task('default', function() {
     .pipe(sourcemaps.init({loadMaps: true}))
         // Add transformation tasks to the pipeline here.
         .pipe(uglify())
-        .on('error', gutil.log)
+        .on('error', log.error)
     .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('./dist/js/'));
 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,7 @@
 'use strict';
 var stampit = require('stampit');
 var validate = require('validate.js');
-var uuid = require('node-uuid');
+var uuidv4 = require('uuid/v4');
 var _ = require('lodash');
 var RequestHelper = require('./request_helper');
 
@@ -60,7 +60,7 @@ function _makeWebsocketUrl(url) {
 }
 
 function _generateRequestId() {
-  return uuid.v4();
+  return uuidv4();
 }
 
 var GiantSwarm = stampit().

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "browserify": ">=10.2.4",
-    "gulp": "^3.9.0",
+    "gulp": "^3.9.1",
     "gulp-eslint": "4.0.1",
     "gulp-sourcemaps": ">=1.5.2",
     "gulp-uglify": ">=1.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-eslint": "4.0.1",
     "gulp-sourcemaps": ">=1.5.2",
     "gulp-uglify": ">=1.2.0",
-    "gulp-util": ">=3.0.5",
+    "fancy-log": "^1.3.2",
     "jasmine": "^2.3.1",
     "vinyl-buffer": ">=1.0.0",
     "vinyl-source-stream": ">=1.1.0"

--- a/package.json
+++ b/package.json
@@ -19,20 +19,20 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "js-base64": "^2.1.8",
-    "js-data": "2.3.0",
+    "js-data": "~3.0.1",
     "lodash": "^4.11.1",
     "node-uuid": "^1.4.7",
-    "stampit": "^2.1.1",
-    "superagent-bluebird-promise": "^3.0.0",
-    "superagent": "1.8.2",
+    "stampit": "^4.0.2",
+    "superagent-bluebird-promise": "^4.2.0",
+    "superagent": "3.8.2",
     "underscore": "^1.8.3",
-    "validate.js": "^0.9.0",
-    "ws": "0.7.2"
+    "validate.js": "^0.12.0",
+    "ws": "4.0.0"
   },
   "devDependencies": {
     "browserify": ">=10.2.4",
     "gulp": "^3.9.0",
-    "gulp-eslint": "0.14.0",
+    "gulp-eslint": "4.0.1",
     "gulp-sourcemaps": ">=1.5.2",
     "gulp-uglify": ">=1.2.0",
     "gulp-util": ">=3.0.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-sourcemaps": ">=1.5.2",
     "gulp-uglify": ">=1.2.0",
     "fancy-log": "^1.3.2",
-    "jasmine": "2.3.2",
+    "jasmine": "2.8.0",
     "vinyl-buffer": ">=1.0.0",
     "vinyl-source-stream": ">=1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "js-base64": "^2.1.8",
     "js-data": "~3.0.1",
     "lodash": "^4.11.1",
-    "node-uuid": "^1.4.7",
+    "uuid": "^3.1.0",
     "stampit": "^4.0.2",
     "superagent-bluebird-promise": "^4.2.0",
     "superagent": "3.8.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-sourcemaps": ">=1.5.2",
     "gulp-uglify": ">=1.2.0",
     "fancy-log": "^1.3.2",
-    "jasmine": "^2.3.1",
+    "jasmine": "2.3.2",
     "vinyl-buffer": ">=1.0.0",
     "vinyl-source-stream": ">=1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "js-base64": "^2.1.8",
-    "js-data": "~3.0.1",
+    "js-data": "2.3.0",
     "lodash": "^4.11.1",
     "uuid": "^3.1.0",
-    "stampit": "^4.0.2",
-    "superagent-bluebird-promise": "^4.2.0",
-    "superagent": "3.8.2",
+    "stampit": "^2.1.1",
+    "superagent-bluebird-promise": "^3.0.0",
+    "superagent": "1.8.2",
     "underscore": "^1.8.3",
-    "validate.js": "^0.12.0",
-    "ws": "4.0.0"
+    "validate.js": "^0.9.0",
+    "ws": "0.7.2"
   },
   "devDependencies": {
     "browserify": ">=10.2.4",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "superagent-bluebird-promise": "^3.0.0",
     "superagent": "1.8.2",
     "underscore": "^1.8.3",
-    "validate.js": "^0.9.0",
-    "ws": "0.7.2"
+    "validate.js": "^0.9.0"
   },
   "devDependencies": {
     "browserify": ">=10.2.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "js-base64": "^2.1.8",
-    "js-data": "2.3.0",
     "lodash": "^4.11.1",
     "uuid": "^3.1.0",
     "stampit": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "bluebird": "^3.3.5",
-    "js-base64": "^2.1.8",
+    "js-base64": "^2.4.0",
     "lodash": "^4.11.1",
     "uuid": "^3.1.0",
     "stampit": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "js-base64": "^2.4.0",
-    "lodash": "^4.11.1",
+    "lodash": "^4.17.4",
     "uuid": "^3.1.0",
     "stampit": "^2.1.1",
     "superagent-bluebird-promise": "^3.0.0",

--- a/spec/client_spec.js
+++ b/spec/client_spec.js
@@ -2,7 +2,7 @@ var stampit = require('stampit');
 
 describe("giantSwarm", function() {
 
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 4000;
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 500;
 
   var GiantSwarm = require('../lib/client');
   var configuration = require('./configuration');

--- a/spec/configuration.js
+++ b/spec/configuration.js
@@ -1,17 +1,18 @@
+/* Configuration variables for tests */
 var configuration = {
   // Fill in credentials of an existing user here
   existingUser: {
-    username: '',
-    password: ''
+    username: 'user@example.com',
+    password: 'password'
   },
 
   // Fill in details of a service you are ok testing against.
   // The service will be stopped and started during the jasmine test.
-  organizationName: '',
-  environmentName: '',
-  serviceName: '',
-  instanceId: '',
-  validToken: ''
+  organizationName: 'orgname',
+  environmentName: 'myenv',
+  serviceName: 'myservice',
+  instanceId: 'myinstance',
+  validToken: 'valid_token'
 }
 
 module.exports = configuration;


### PR DESCRIPTION
Towards https://github.com/giantswarm/happa/issues/124

This does several things, none of which alter the client functionality:

- Change CircleCI config to use a machine instead of docker, so tests can run in docker containers as soon as https://github.com/giantswarm/mock-api/pull/44 is done
- Remove deprecated gulp-util dependency
- Remove deprecated node-uuid dependency
- Update gulp-eslint
- Change jasmine test configuration so it can be distributed in the repo

Jasmine tests are running locally where the image `quay.io/giantswarm/mock-api:latest` is available, but they are failing. So no point in adding them to the CircleCI now.