### PR TITLE
Update client to match latest API spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-api-spec/
-node_modules/
+/api-spec/
+/node_modules/
+/package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ generate: api-spec
 		--lang javascript \
 		--output /repo
 	mv README.md DOCS.md
+	# fix superagent dependency due to security issue
+	sed -i 's@"superagent": "3.5.2"@"superagent": "3.7.0"@;' package.json
+	sed -i 's@"mocha": "~2.3.4"@"mocha": "^5.2.0"@;' package.json
 
 # Copies the public API spec YAML to a local folder
 api-spec:

--- a/docs/V4AddClusterRequest.md
+++ b/docs/V4AddClusterRequest.md
@@ -6,7 +6,6 @@ Name | Type | Description | Notes
 **owner** | **String** | Name of the organization owning the cluster | 
 **name** | **String** | Cluster name | [optional] 
 **releaseVersion** | **String** | The [release](https://docs.giantswarm.io/api/#tag/releases) version to use in the new cluster  | [optional] 
-**kubernetesVersion** | **String** | Kubernetes version number (deprecated). Doesn&#39;t have any effect. This attribute is going to be removed in future API versions.  | [optional] 
 **workers** | [**[V4NodeDefinition]**](V4NodeDefinition.md) |  | [optional] 
 
 

--- a/docs/V4ClusterDetailsResponse.md
+++ b/docs/V4ClusterDetailsResponse.md
@@ -9,7 +9,6 @@ Name | Type | Description | Notes
 **owner** | **String** | Name of the organization owning the cluster | [optional] 
 **name** | **String** | Cluster name | [optional] 
 **releaseVersion** | **String** | The [release](https://docs.giantswarm.io/api/#tag/releases) version currently running this cluster.  | [optional] 
-**kubernetesVersion** | **String** | Deprecated. Will be removed in a future API version. | [optional] 
 **workers** | [**[V4NodeDefinition]**](V4NodeDefinition.md) |  | [optional] 
 **kvm** | [**V4ClusterDetailsResponseKvm**](V4ClusterDetailsResponseKvm.md) |  | [optional] 
 

--- a/docs/V4ClusterDetailsResponseKvm.md
+++ b/docs/V4ClusterDetailsResponseKvm.md
@@ -3,6 +3,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**portMappings** | [**[V4ClusterDetailsResponseKvmPortMappings]**](V4ClusterDetailsResponseKvmPortMappings.md) | Reveals the ports on the host cluster that are mapped to this guest cluster&#39;s ingress and which protocol that port supports. Only shown and relevant on our on-prem KVM clusters.  | [optional] 
+**portMappings** | [**[V4ClusterDetailsResponseKvmPortMappings]**](V4ClusterDetailsResponseKvmPortMappings.md) | Reveals the ports on the control plane that are mapped to this tenant cluster&#39;s ingress and which protocol that port supports. Only shown and relevant on our on-prem KVM clusters.  | [optional] 
 
 

--- a/docs/V4ClusterDetailsResponseKvmPortMappings.md
+++ b/docs/V4ClusterDetailsResponseKvmPortMappings.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**port** | **Number** | The port on the host cluster that will forward traffic to the guest cluster  | [optional] 
+**port** | **Number** | The port on the control plane that will forward traffic to the tenant cluster  | [optional] 
 **protocol** | **String** | The protocol this port mapping is made for.  | [optional] 
 
 

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "fs": false
   },
   "dependencies": {
-    "superagent": "3.5.2"
+    "superagent": "3.7.0"
   },
   "devDependencies": {
-    "mocha": "~2.3.4",
+    "mocha": "^5.2.0",
     "sinon": "1.17.3",
     "expect.js": "~0.3.1"
   }

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "fs": false
   },
   "dependencies": {
-    "superagent": "3.7.0"
+    "superagent": "3.5.2"
   },
   "devDependencies": {
-    "expect.js": "~0.3.1",
-    "mocha": "^5.2.0",
-    "sinon": "1.17.3"
+    "mocha": "~2.3.4",
+    "sinon": "1.17.3",
+    "expect.js": "~0.3.1"
   }
 }

--- a/src/model/V4AddClusterRequest.js
+++ b/src/model/V4AddClusterRequest.js
@@ -53,7 +53,6 @@
 
 
 
-
   };
 
   /**
@@ -75,9 +74,6 @@
       }
       if (data.hasOwnProperty('release_version')) {
         obj['release_version'] = ApiClient.convertToType(data['release_version'], 'String');
-      }
-      if (data.hasOwnProperty('kubernetes_version')) {
-        obj['kubernetes_version'] = ApiClient.convertToType(data['kubernetes_version'], 'String');
       }
       if (data.hasOwnProperty('workers')) {
         obj['workers'] = ApiClient.convertToType(data['workers'], [V4NodeDefinition]);
@@ -101,11 +97,6 @@
    * @member {String} release_version
    */
   exports.prototype['release_version'] = undefined;
-  /**
-   * Kubernetes version number (deprecated). Doesn't have any effect. This attribute is going to be removed in future API versions. 
-   * @member {String} kubernetes_version
-   */
-  exports.prototype['kubernetes_version'] = undefined;
   /**
    * @member {Array.<module:model/V4NodeDefinition>} workers
    */

--- a/src/model/V4ClusterDetailsResponse.js
+++ b/src/model/V4ClusterDetailsResponse.js
@@ -56,7 +56,6 @@
 
 
 
-
   };
 
   /**
@@ -87,9 +86,6 @@
       }
       if (data.hasOwnProperty('release_version')) {
         obj['release_version'] = ApiClient.convertToType(data['release_version'], 'String');
-      }
-      if (data.hasOwnProperty('kubernetes_version')) {
-        obj['kubernetes_version'] = ApiClient.convertToType(data['kubernetes_version'], 'String');
       }
       if (data.hasOwnProperty('workers')) {
         obj['workers'] = ApiClient.convertToType(data['workers'], [V4NodeDefinition]);
@@ -131,11 +127,6 @@
    * @member {String} release_version
    */
   exports.prototype['release_version'] = undefined;
-  /**
-   * Deprecated. Will be removed in a future API version.
-   * @member {String} kubernetes_version
-   */
-  exports.prototype['kubernetes_version'] = undefined;
   /**
    * @member {Array.<module:model/V4NodeDefinition>} workers
    */

--- a/src/model/V4ClusterDetailsResponseKvm.js
+++ b/src/model/V4ClusterDetailsResponseKvm.js
@@ -70,7 +70,7 @@
   }
 
   /**
-   * Reveals the ports on the host cluster that are mapped to this guest cluster's ingress and which protocol that port supports. Only shown and relevant on our on-prem KVM clusters. 
+   * Reveals the ports on the control plane that are mapped to this tenant cluster's ingress and which protocol that port supports. Only shown and relevant on our on-prem KVM clusters. 
    * @member {Array.<module:model/V4ClusterDetailsResponseKvmPortMappings>} port_mappings
    */
   exports.prototype['port_mappings'] = undefined;

--- a/src/model/V4ClusterDetailsResponseKvmPortMappings.js
+++ b/src/model/V4ClusterDetailsResponseKvmPortMappings.js
@@ -73,7 +73,7 @@
   }
 
   /**
-   * The port on the host cluster that will forward traffic to the guest cluster 
+   * The port on the control plane that will forward traffic to the tenant cluster 
    * @member {Number} port
    */
   exports.prototype['port'] = undefined;


### PR DESCRIPTION
This updates the client to pick up latest API changes.

- `V4ClusterDetailsResponse` no longer contains the `kubernetesVersion` attribute
- `V4AddClusterRequest ` no longer supports the `kubernetesVersion` attribute

This also modifies the build so that `superagent` and `mocha` dependency versions are automatically overwritten to use newer versions.