### PR TITLE
Remove V4 from module name

### DIFF
--- a/swagger-codegen-conf.json
+++ b/swagger-codegen-conf.json
@@ -1,8 +1,8 @@
 {
-    "projectName": "giantswarm-v4",
+    "projectName": "giantswarm-",
     "projectVersion": "4.0.0",
-    "moduleName": "GiantSwarmV4",
-    "projectDescription": "Generated JavaScript client for the Giant Swarm API v4.",
+    "moduleName": "GiantSwarm",
+    "projectDescription": "Generated JavaScript client for the Giant Swarm API.",
     "useES6": false,
     "usePromises": true
 }


### PR DESCRIPTION
@ograu This would change the module name so that it does not contain "v4" any more.

After merging, needs `make clean && make generate` again in the node-pools branch.